### PR TITLE
<Experience> AI 체험 온보딩 결과 화면 반환 및 수정 기능 구현

### DIFF
--- a/back-end/src/main/java/com/onnongwa/back_end/domain/config/WebConfig.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/config/WebConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.*;
 
 @Configuration
-public class WebConfig {
+public class WebConfig  implements WebMvcConfigurer{
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
@@ -18,5 +18,13 @@ public class WebConfig {
                         .allowCredentials(true);
             }
         };
+    }
+
+    // 정적 리소스 경로 매핑
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // http://localhost:8080/uploads/** 로 접근하면 프로젝트 내부 /uploads/ 폴더 파일을 서빙
+        registry.addResourceHandler("/uploads/**")
+            .addResourceLocations("file:" + System.getProperty("user.dir") + "/uploads/");
     }
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
@@ -12,7 +12,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDTO;
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpOnboardingDto;
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
 import com.onnongwa.back_end.domain.experience.service.ExperienceService;
 import com.onnongwa.back_end.open_api.service.OpenApiService;
 
@@ -26,9 +27,17 @@ public class ExperienceController {
 	private final ExperienceService experienceService;
 	private final OpenApiService openApiService;
 
-	@PostMapping("/onboarding")
-	public ResponseEntity<?> generateExperienceContent(@RequestBody ExpRegisterDTO dto){
 
+	@PostMapping
+	public ResponseEntity<?> registerExperience(@RequestBody ExpRegisterDto dto){
+
+		System.out.println("전달 테스트 : \n" + dto.toString());
+		experienceService.registerExperience(dto);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@PostMapping("/onboarding")
+	public ResponseEntity<?> generateExperienceContent(@RequestBody ExpOnboardingDto dto){
 		return ResponseEntity.ok(openApiService.getChatCompletion(dto.toString()));
 
 	}
@@ -37,7 +46,6 @@ public class ExperienceController {
 	public ResponseEntity<?> imageUpload(@RequestParam("file")MultipartFile file) throws IOException {
 
 		String url = experienceService.saveImageAndGetUrl(file);
-
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(Map.of("url", url));
 	}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpOnboardingDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpOnboardingDto.java
@@ -2,7 +2,7 @@ package com.onnongwa.back_end.domain.experience.controller.dto;
 
 import java.util.List;
 
-public record ExpRegisterDTO(
+public record ExpOnboardingDto(
 	String title,
 	String region,
 	String address,

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpRegisterDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpRegisterDto.java
@@ -1,0 +1,52 @@
+package com.onnongwa.back_end.domain.experience.controller.dto;
+
+import java.util.List;
+
+public record ExpRegisterDto(
+	// 기본 정보
+	String title,
+	String location,
+	String duration,
+	String price,
+	List<String> availableDates,
+	String description,
+	String imageUrl,
+
+	// 상세 정보
+	String address,
+	String placeType,
+	String regionType,
+	String crops,
+	String operatingHours,
+	List<String> closedDays,
+	int minParticipants,
+	int maxParticipants,
+
+	// 일정
+	List<ScheduleItem> schedule,
+
+	// 하이라이트
+	List<String> highlights,
+
+	// 포함 사항
+	List<String> inclusions,
+
+	// 해시태그
+	List<String> hashtags,
+
+	// 담당자
+	HostInfo host
+
+) {
+	public record ScheduleItem(
+		String time,
+		String activity
+	) {}
+
+	public record HostInfo(
+		String name,
+		String phone,
+		String email,
+		String farmName
+	) {}
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
@@ -5,11 +5,7 @@ import java.util.List;
 
 import com.onnongwa.back_end.domain.farm.entity.Farm;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -17,27 +13,67 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder(toBuilder = true)
 public class Experience {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String title;
-    private String description;
-    private String image; // 대표 이미지 URL
-    private int totalTime; // 체험 시간 예) "09:00 - 12:00"
-    private int price;
-    private String schedule;
-    private int minCapacity;
-    private int maxCapacity;
-    private String url;
-    private String hashTag;
+    // 기본 정보
+    private String title;           // 제목
+    private String description;     // 설명
+    private String location;        // 지역 (ex: 강원도 평창군)
+    private String duration;        // 총 소요 시간 (ex: "약 5시간")
+    private int price;              // 가격
+    private String address;         // 주소
+    private String placeType;       // 실내/실외
+    private String regionType;      // 농촌/어촌
+    private String crops;           // 주요 작물 (콤마 구분)
 
-    @Enumerated(EnumType.STRING)
-    private Location locationType;
+    // 운영 정보
+    private String operatingHours;  // 운영 시간 (ex: "09:00 - 18:00")
+
+    private int minParticipants;    // 최소 인원
+    private int maxParticipants;    // 최대 인원
+
+    private String imageUrl;        // 대표 이미지 URL
+
+    @ElementCollection
+    @CollectionTable(name = "experience_closed_days", joinColumns = @JoinColumn(name = "experience_id"))
+    @Column(name = "day")
+    private List<String> closedDays = new ArrayList<>(); // 휴무일
+
+
+    // 하이라이트
+    @ElementCollection
+    @CollectionTable(name = "experience_highlights", joinColumns = @JoinColumn(name = "experience_id"))
+    @Column(name = "highlight")
+    private List<String> highlights = new ArrayList<>();
+
+    // 포함 사항
+    @ElementCollection
+    @CollectionTable(name = "experience_inclusions", joinColumns = @JoinColumn(name = "experience_id"))
+    @Column(name = "inclusion")
+    private List<String> inclusions = new ArrayList<>();
+
+    // 해시태그
+    @ElementCollection
+    @CollectionTable(name = "experience_hashtags", joinColumns = @JoinColumn(name = "experience_id"))
+    @Column(name = "hashtag")
+    private List<String> hashtags = new ArrayList<>();
+
+    // 담당자 정보 (Host)
+    private String hostName;
+    private String hostPhone;
+    private String hostEmail;
+    private String hostFarmName;
+
+    // 관계
+
+    // 일정
+    @OneToMany(mappedBy = "experience", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExperienceSchedule> schedule = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "farm_id", nullable = false)
     private Farm farm;
-
-    @OneToMany(mappedBy = "experience", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ExperienceSchedule> scheduleItems = new ArrayList<>();
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
@@ -10,8 +10,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDTO;
-import com.onnongwa.back_end.open_api.dto.AiOnboardingDTO;
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
 import com.onnongwa.back_end.open_api.service.OpenApiService;
 
 import lombok.RequiredArgsConstructor;
@@ -23,7 +22,9 @@ public class ExperienceService {
 	private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
 	private final String IMAGE_BASE_URL = "/uploads/";
 
-	private final OpenApiService openApiService;
+	public void registerExperience(ExpRegisterDto dto){
+
+	}
 
 	public String saveImageAndGetUrl(MultipartFile file) throws IOException{
 		if (file.isEmpty()){

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class ExperienceService {
 
 	private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
-	private final String IMAGE_BASE_URL = "/images/";
+	private final String IMAGE_BASE_URL = "/uploads/";
 
 	private final OpenApiService openApiService;
 
@@ -41,6 +41,9 @@ public class ExperienceService {
 		Path path = Paths.get(UPLOAD_DIR + savedFileName);
 
 		Files.copy(file.getInputStream(), path, StandardCopyOption.REPLACE_EXISTING);
+
+		System.out.println(IMAGE_BASE_URL + savedFileName);
+
 
 		return IMAGE_BASE_URL + savedFileName;
 	}

--- a/back-end/src/main/java/com/onnongwa/back_end/open_api/dto/AiOnboardingDTO.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/open_api/dto/AiOnboardingDTO.java
@@ -6,10 +6,19 @@ public record AiOnboardingDTO(
 	String title,
 	String region,
 	String address,
+	String placeType,               // 추가
+	String regionType,              // 추가
 	String description,
+	String duration,
 	String crops,
 	int price,
-	List<String> scheduleItems, // scheduleItems=10:00-농장 도착... ; 10:30-...
+	List<String> scheduleItems,
+	List<String> highlights,        // 추가
+	List<String> inclusions,        // 추가
+	List<String> hashtags,          // 추가
+	String startTime,               // 추가
+	String endTime,                 // 추가
+	List<String> selectedClosedDays,// 추가
 	int minParticipants,
 	int maxParticipants,
 	String hostName,

--- a/back-end/src/main/java/com/onnongwa/back_end/open_api/service/ChatResponseParser.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/open_api/service/ChatResponseParser.java
@@ -29,14 +29,53 @@ public class ChatResponseParser {
 				.collect(Collectors.toList());
 		}
 
+		// selectedClosedDays는 ,로 분리
+		List<String> selectedClosedDays = new ArrayList<>();
+		if (map.containsKey("selectedClosedDays")) {
+			selectedClosedDays = Arrays.stream(map.get("selectedClosedDays").split(","))
+				.map(String::trim)
+				.collect(Collectors.toList());
+		}
+
+		// highlights, inclusions, hashtags는 ,로 분리
+		List<String> highlights = new ArrayList<>();
+		if (map.containsKey("highlights")) {
+			highlights = Arrays.stream(map.get("highlights").split(","))
+				.map(String::trim)
+				.collect(Collectors.toList());
+		}
+
+		List<String> inclusions = new ArrayList<>();
+		if (map.containsKey("inclusions")) {
+			inclusions = Arrays.stream(map.get("inclusions").split(","))
+				.map(String::trim)
+				.collect(Collectors.toList());
+		}
+
+		List<String> hashtags = new ArrayList<>();
+		if (map.containsKey("hashtags")) {
+			hashtags = Arrays.stream(map.get("hashtags").split(","))
+				.map(String::trim)
+				.collect(Collectors.toList());
+		}
+
 		return new AiOnboardingDTO(
 			map.getOrDefault("title", ""),
 			map.getOrDefault("region", ""),
 			map.getOrDefault("address", ""),
+			map.getOrDefault("placeType", ""),
+			map.getOrDefault("regionType", ""),
 			map.getOrDefault("description", ""),
+			map.getOrDefault("duration", ""),
 			map.getOrDefault("crops", ""),
 			Integer.parseInt(map.getOrDefault("price", "0")),
 			scheduleItems,
+			highlights,
+			inclusions,
+			hashtags,
+			map.getOrDefault("startTime", ""),
+			map.getOrDefault("endTime", ""),
+			selectedClosedDays,
 			Integer.parseInt(map.getOrDefault("minParticipants", "0")),
 			Integer.parseInt(map.getOrDefault("maxParticipants", "0")),
 			map.getOrDefault("hostName", ""),

--- a/back-end/src/main/java/com/onnongwa/back_end/open_api/service/OpenApiService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/open_api/service/OpenApiService.java
@@ -33,7 +33,8 @@ public class OpenApiService {
 	public AiOnboardingDTO getChatCompletion(String prompt){
 
 		List<Map<String, String>> messages = List.of(
-			Map.of("role", "system", "content", "당신은 농촌 체험 마케팅 전문가입니다.\n"
+			Map.of("role", "system", "content",
+				"당신은 농촌 체험 마케팅 전문가입니다.\n"
 				+ "사용자가 전달한 체험 정보를 바탕으로, 각 속성을 **흥미롭고 재밌게, 사람들의 관심을 유발하도록 리브랜딩**합니다.\n"
 				+ "- 체험 내용 자체는 변경하지 않습니다.\n"
 				+ "- 말투와 표현만 바꾸어, 노동이 아닌 **힐링과 즐거움을 느낄 수 있는 느낌**을 강조합니다.\n"
@@ -44,7 +45,7 @@ public class OpenApiService {
 				+ "- 무조건 예시의 양식대로 작성해줘\n"
 				+ "- 정리된 ScheduleItems을 토대로 총 체험이 몇시간 걸리는지 숫자만 적어줘 예) duration=3"
 				+ "- 온보딩 된 내용을 토대로 이 체험의 highlights 4가지 작성해줘 highlights는 ,로 분리해줘 예) 전문가와 함께하는 숲속 명상, 다도 체험 및 전통차 시음"
-				+ "- 온보딩된 내용을 토대로 이 체험의 inclusions도 1~3 가지 정도 작성해줘 inclusions는 ,로 분리해줘 예 ) 명상 도구 대여, 전문가 가이드"
+				+ "- 온보딩 된 내용을 토대로 이 체험의 inclusions도 1~3 가지 정도 작성해줘 inclusions는 ,로 분리해줘 예 ) 명상 도구 대여, 전문가 가이드"
 				+ "- 최종적으로 모든 내용을 가지고 hashtags를 추출해서 4가지 정도 작성해줘 hashtags는 ,로 분리해줘 예 ) #숲속명상, #차담, #힐링체험"
 				+ "예:\n"
 				+ "title=...\n"

--- a/back-end/src/main/java/com/onnongwa/back_end/open_api/service/OpenApiService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/open_api/service/OpenApiService.java
@@ -40,15 +40,29 @@ public class OpenApiService {
 				+ "- 출력 형식은 **key=value**, 속성별로 한 줄씩 반드시 작성합니다.\n"
 				+ "- ScheduleItems는 한 줄에 `시간-활동` 형태로 `;`로 구분하여 작성합니다.\n"
 				+ "- title, description, ScheduleItems 이 세가지만 리브랜딩해주고 나머지는 그대로 정돈만해줘!"
-				+ "- description 의 내용은 좀 더 풍부하게 해줘 500자 이하로"
+				+ "- description 의 내용은 좀 더 풍부하게 해줘 500자 이하로\n"
+				+ "- 무조건 예시의 양식대로 작성해줘\n"
+				+ "- 정리된 ScheduleItems을 토대로 총 체험이 몇시간 걸리는지 숫자만 적어줘 예) duration=3"
+				+ "- 온보딩 된 내용을 토대로 이 체험의 highlights 4가지 작성해줘 highlights는 ,로 분리해줘 예) 전문가와 함께하는 숲속 명상, 다도 체험 및 전통차 시음"
+				+ "- 온보딩된 내용을 토대로 이 체험의 inclusions도 1~3 가지 정도 작성해줘 inclusions는 ,로 분리해줘 예 ) 명상 도구 대여, 전문가 가이드"
+				+ "- 최종적으로 모든 내용을 가지고 hashtags를 추출해서 4가지 정도 작성해줘 hashtags는 ,로 분리해줘 예 ) #숲속명상, #차담, #힐링체험"
 				+ "예:\n"
 				+ "title=...\n"
 				+ "region=...\n"
 				+ "address=...\n"
+				+ "placeType=...\n"
+				+ "duration=...\n"
+				+ "regionType=...\n"
 				+ "description=...\n"
 				+ "crops=...\n"
 				+ "price=...\n"
 				+ "scheduleItems=...\n"
+				+ "highlights=... \n"
+				+ "inclusions=...\n"
+				+ "hashtags=...\n"
+				+ "startTime=...\n"
+				+ "endTime=...\n"
+				+ "selectedClosedDays=...\n"
 				+ "minParticipants=...\n"
 				+ "maxParticipants=...\n"
 				+ "hostName=...\n"
@@ -78,6 +92,8 @@ public class OpenApiService {
 			if (res == null || res.outputText() == null){
 				throw new RuntimeException("빈 응답");
 			}
+
+			System.out.println("결과 양식 \n" + res.outputText());
 
 			return ChatResponseParser.parse(res.outputText());
 		} catch(Exception e){

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -85,7 +85,7 @@ export default function App() {
                         path="/register/ai-generate"
                         element={
                             <Layout header={{ title: "체험 등록 정보 확인", backTo: "/register/onboarding" }}>
-                                <GenerateOnboardingPage />
+                                <AiGeneratePage />
                             </Layout>
                         }
                     />

--- a/front-end/src/pages/register/RegisterOptionsPage.tsx
+++ b/front-end/src/pages/register/RegisterOptionsPage.tsx
@@ -41,7 +41,7 @@ export default function RegisterOptionsPage() {
                             기존 체험 정보를 입력하면 AI가 매력적인 홍보글을 자동으로 작성하여 등록을 돕습니다.
                         </p>
                         <Link
-                            to="/register/ai-generate"
+                            to="/register/onboarding"
                             className="w-full inline-block px-4 py-2 rounded bg-primary text-primary-foreground hover:bg-primary/90"
                         >
                             직접 등록하기

--- a/front-end/src/pages/register/generate/AiGeneratePage.tsx
+++ b/front-end/src/pages/register/generate/AiGeneratePage.tsx
@@ -5,6 +5,8 @@ import {
     Edit, CheckCircle, MapPin, Clock, Users, Calendar, Tag,
     Mail, Phone, Sparkles
 } from "lucide-react";
+import { useLocation } from "react-router-dom";
+import { useEffect } from "react";
 
 // (임시) 등록 API — 나중에 실제 백엔드 연동으로 교체
 async function registerExperience(payload: unknown): Promise<{success:boolean; message:string}> {
@@ -94,7 +96,73 @@ const initialData: ExperienceData = {
 };
 
 export default function AiGenerateReviewPage() {
-    const [data] = useState<ExperienceData>(initialData);
+
+    const location = useLocation();
+    const { result } = location.state || {}; // 안전하게 구조 분해
+
+    useEffect(() => {
+        console.log("이전 페이지에서 받은 데이터:", result);
+    }, [result]);
+
+    const [data, setData] = useState<ExperienceData>(() => {
+        if (!result) return {} as ExperienceData;
+
+        // placeType, regionType 한국어 변환
+        const placeTypeMap: Record<string, string> = { indoor: "실내", outdoor: "실외" };
+        const regionTypeMap: Record<string, string> = { rural: "농촌", fishing: "어촌" };
+
+        // selectedClosedDays 정리
+        const rawClosedDays = result.selectedClosedDays || [];
+
+        const cleaned = rawClosedDays.join(",").replace(/[\[\]]/g, "");
+
+        const closedDays = cleaned
+            .split(/(요일)/)          // "요일"을 기준으로 split
+            .map(s => s.trim())       // 공백 제거
+            .filter(s => s !== "")    // 빈 문자열 제거
+            .reduce((acc: string[], curr, idx, arr) => {
+                if (curr === "요일") {
+                    acc[acc.length - 1] += curr; // 이전 값 뒤에 "요일" 붙이기
+                } else if (curr !== ",") {
+                    acc.push(curr);
+                }
+                return acc;
+            }, []);
+
+        // scheduleItems 변환
+        const schedule = (result.scheduleItems || []).map((s: string) => {
+            const [time, ...rest] = s.split("-");
+            return { time: time.trim(), activity: rest.join("-").trim() };
+        });
+
+        return {
+            title: result.title,
+            aiPromotionalText: result.description || "",
+            location: result.region,
+            address: result.address,
+            placeType: placeTypeMap[result.placeType] || "실내",
+            regionType: regionTypeMap[result.regionType] || "농촌",
+            crops: result.crops,
+            price: String(result.price),
+            duration: "약 " + result.duration + "시간", // 운영 시간은 추후 입력
+            availableDates: closedDays,
+            operatingHours: `${result.startTime || ""} - ${result.endTime || ""}`,
+            closedDays: closedDays,
+            minParticipants: result.minParticipants,
+            maxParticipants: result.maxParticipants,
+            schedule,
+            highlights: result.highlights,
+            inclusions: result.inclusions,
+            hashtags: result.hashtags,
+            host: {
+                name: result.hostName,
+                phone: result.hostPhone,
+                email: result.hostEmail,
+                farmName: result.farmName
+            },
+            imageUrl: result.imageUrl
+        };
+    });
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     // 편집 토글

--- a/front-end/src/pages/register/generate/AiGeneratePage.tsx
+++ b/front-end/src/pages/register/generate/AiGeneratePage.tsx
@@ -177,11 +177,32 @@ export default function AiGenerateReviewPage() {
     const [editHost, setEditHost] = useState(false);
 
     const handleSubmit = async () => {
-        setIsSubmitting(true);
-        const payload = { ...data, aiPromotionalText: promoText };
-        const result = await registerExperience(payload);
-        alert(`${result.success ? "✅" : "❌"} ${result.message}`);
-        setIsSubmitting(false);
+        try {
+            setIsSubmitting(true);
+
+            // payload 구성: data + aiPromotionalText 포함
+            const payload = { ...data, aiPromotionalText: promoText };
+
+            const response = await fetch("/api/v1/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) throw new Error("등록 실패");
+
+            const result = await response.json();
+
+            // alert 출력
+            alert(`${result.success ? "✅" : "❌"} ${result.message}`);
+        } catch (error) {
+            console.error(error);
+            alert("❌ 등록 실패. 다시 시도해주세요.");
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
     return (
@@ -199,14 +220,14 @@ export default function AiGenerateReviewPage() {
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <Sparkles className="h-6 w-6 text-primary" />
+                                <Sparkles className="h-6 w-6 text-primary"/>
                                 AI가 작성한 홍보글
                             </h3>
                             <button
                                 className="px-3 py-1.5 rounded border text-sm"
                                 onClick={() => setEditPromo(!editPromo)}
                             >
-                                <Edit className="h-4 w-4 inline mr-1" />
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editPromo ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
@@ -223,34 +244,62 @@ export default function AiGenerateReviewPage() {
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <MapPin className="h-6 w-6 text-primary" />
+                                <MapPin className="h-6 w-6 text-primary"/>
                                 기본 정보
                             </h3>
-                            <button className="px-3 py-1.5 rounded border text-sm" onClick={() => setEditBasic(!editBasic)}>
-                                <Edit className="h-4 w-4 inline mr-1" />
+                            <button className="px-3 py-1.5 rounded border text-sm"
+                                    onClick={() => setEditBasic(!editBasic)}>
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editBasic ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
                         {editBasic ? (
                             <div className="grid grid-cols-2 gap-3 text-sm">
-                                <input className="border rounded px-2 py-1" placeholder="위치" defaultValue={data.location} />
-                                <input className="border rounded px-2 py-1" placeholder="기간" defaultValue={data.duration} />
-                                <input className="border rounded px-2 py-1" placeholder="가격" defaultValue={data.price} />
-                                <input className="border rounded px-2 py-1" placeholder="이용 가능 날짜" defaultValue={data.availableDates} />
+                                <input
+                                    className="border rounded px-2 py-1"
+                                    placeholder="위치"
+                                    value={data.location}
+                                    onChange={(e) => setData({...data, location: e.target.value})}
+                                />
+                                <input
+                                    className="border rounded px-2 py-1"
+                                    placeholder="기간"
+                                    value={data.duration}
+                                    onChange={(e) => setData({...data, duration: e.target.value})}
+                                />
+                                <input
+                                    className="border rounded px-2 py-1"
+                                    placeholder="가격"
+                                    value={data.price}
+                                    onChange={(e) => setData({...data, price: e.target.value})}
+                                />
+                                <input
+                                    className="border rounded px-2 py-1"
+                                    placeholder="이용 가능 날짜"
+                                    value={data.availableDates}
+                                    onChange={(e) => setData({...data, availableDates: e.target.value})}
+                                />
                             </div>
                         ) : (
                             <div className="grid grid-cols-2 gap-4 text-sm">
-                                <div className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
-                                    <MapPin className="h-6 w-6 mb-2" /><span className="font-medium">{data.location}</span>
+                                <div
+                                    className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
+                                    <MapPin className="h-6 w-6 mb-2"/><span
+                                    className="font-medium">{data.location}</span>
                                 </div>
-                                <div className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
-                                    <Clock className="h-6 w-6 mb-2" /><span className="font-medium">{data.duration}</span>
+                                <div
+                                    className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
+                                    <Clock className="h-6 w-6 mb-2"/><span
+                                    className="font-medium">{data.duration}</span>
                                 </div>
-                                <div className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
-                                    <Users className="h-6 w-6 mb-2" /><span className="font-medium">{data.price}</span>
+                                <div
+                                    className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
+                                    <Users className="h-6 w-6 mb-2"/><span className="font-medium">{data.price}</span>
                                 </div>
-                                <div className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
-                                    <Calendar className="h-6 w-6 mb-2" /><span className="font-medium">{data.availableDates}</span>
+                                <div
+                                    className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
+                                    <Calendar className="h-6 w-6 mb-2"/><span
+                                    className="font-medium">{data.availableDates}</span>
                                 </div>
                             </div>
                         )}
@@ -260,23 +309,95 @@ export default function AiGenerateReviewPage() {
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <CheckCircle className="h-6 w-6 text-primary" />
+                                <CheckCircle className="h-6 w-6 text-primary"/>
                                 체험 상세 정보
                             </h3>
-                            <button className="px-3 py-1.5 rounded border text-sm" onClick={() => setEditDetails(!editDetails)}>
-                                <Edit className="h-4 w-4 inline mr-1" />
+                            <button className="px-3 py-1.5 rounded border text-sm"
+                                    onClick={() => setEditDetails(!editDetails)}>
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editDetails ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
                         {editDetails ? (
                             <ul className="space-y-2 text-base">
-                                <li><span className="font-medium">주소:</span> <input className="border rounded px-2 py-1 w-full" defaultValue={data.address} /></li>
-                                <li><span className="font-medium">장소 유형:</span> <input className="border rounded px-2 py-1" defaultValue={data.placeType} /></li>
-                                <li><span className="font-medium">지역 유형:</span> <input className="border rounded px-2 py-1" defaultValue={data.regionType} /></li>
-                                <li><span className="font-medium">관련 작물:</span> <input className="border rounded px-2 py-1" defaultValue={data.crops} /></li>
-                                <li><span className="font-medium">운영 시간:</span> <input className="border rounded px-2 py-1" defaultValue={data.operatingHours} /></li>
-                                <li><span className="font-medium">휴무일:</span> <input className="border rounded px-2 py-1 w-full" defaultValue={data.closedDays.join(", ")} /></li>
-                                <li><span className="font-medium">참가 인원:</span> 최소 <input type="number" defaultValue={data.minParticipants} className="border rounded px-2 py-1 w-20 inline-block" /> 명 ~ 최대 <input type="number" defaultValue={data.maxParticipants} className="border rounded px-2 py-1 w-20 inline-block" /> 명</li>
+                                <li>
+                                    <span className="font-medium">주소:</span>
+                                    <input
+                                        className="border rounded px-2 py-1 w-full"
+                                        value={data.address}
+                                        onChange={(e) => setData({...data, address: e.target.value})}
+                                    />
+                                </li>
+                                <li>
+                                    <span className="font-medium">장소 유형:</span>
+                                    <input
+                                        className="border rounded px-2 py-1"
+                                        value={data.placeType}
+                                        onChange={(e) => setData({...data, placeType: e.target.value})}
+                                    />
+                                </li>
+                                <li>
+                                    <span className="font-medium">지역 유형:</span>
+                                    <input
+                                        className="border rounded px-2 py-1"
+                                        value={data.regionType}
+                                        onChange={(e) => setData({...data, regionType: e.target.value})}
+                                    />
+                                </li>
+                                <li>
+                                    <span className="font-medium">관련 작물:</span>
+                                    <input
+                                        className="border rounded px-2 py-1"
+                                        value={data.crops}
+                                        onChange={(e) => setData({...data, crops: e.target.value})}
+                                    />
+                                </li>
+                                <li>
+                                    <span className="font-medium">운영 시간:</span>
+                                    <input
+                                        className="border rounded px-2 py-1"
+                                        value={data.operatingHours}
+                                        onChange={(e) => setData({...data, operatingHours: e.target.value})}
+                                    />
+                                </li>
+                                <li>
+                                    <span className="font-medium">휴무일:</span>
+                                    <input
+                                        className="border rounded px-2 py-1 w-full"
+                                        value={data.closedDays.join(", ")} // 보기용 문자열
+                                        onChange={(e) => {
+                                            // 입력값을 쉼표 또는 줄바꿈 기준으로 나누고
+                                            // 공백 제거, 빈 문자열 제거
+                                            const cleaned = e.target.value
+                                                .split(/,|\n/)        // 쉼표나 줄바꿈 기준으로 분리
+                                                .map(s => s.trim())    // 공백 제거
+                                                .filter(s => s.length > 0); // 빈 문자열 제거
+                                            setData({...data, closedDays: cleaned});
+                                        }}
+                                    />
+                                </li>
+                                <li>
+                                    <span className="font-medium">참가 인원:</span>
+                                    최소{" "}
+                                    <input
+                                        type="number"
+                                        className="border rounded px-2 py-1 w-20 inline-block"
+                                        value={data.minParticipants}
+                                        onChange={(e) =>
+                                            setData({...data, minParticipants: parseInt(e.target.value) || 1})
+                                        }
+                                    />{" "}
+                                    명 ~ 최대{" "}
+                                    <input
+                                        type="number"
+                                        className="border rounded px-2 py-1 w-20 inline-block"
+                                        value={data.maxParticipants}
+                                        onChange={(e) =>
+                                            setData({...data, maxParticipants: parseInt(e.target.value) || 1})
+                                        }
+                                    />{" "}
+                                    명
+                                </li>
                             </ul>
                         ) : (
                             <ul className="space-y-2 text-base">
@@ -286,7 +407,9 @@ export default function AiGenerateReviewPage() {
                                 <li><span className="font-medium">관련 작물:</span> {data.crops}</li>
                                 <li><span className="font-medium">운영 시간:</span> {data.operatingHours}</li>
                                 <li><span className="font-medium">휴무일:</span> {data.closedDays.join(", ")}</li>
-                                <li><span className="font-medium">참가 인원:</span> 최소 {data.minParticipants}명 ~ 최대 {data.maxParticipants}명</li>
+                                <li><span className="font-medium">참가 인원:</span> 최소 {data.minParticipants}명 ~
+                                    최대 {data.maxParticipants}명
+                                </li>
                             </ul>
                         )}
                     </section>
@@ -295,24 +418,51 @@ export default function AiGenerateReviewPage() {
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <Calendar className="h-6 w-6 text-primary" />
+                                <Calendar className="h-6 w-6 text-primary"/>
                                 체험 일정
                             </h3>
-                            <button className="px-3 py-1.5 rounded border text-sm" onClick={() => setEditSchedule(!editSchedule)}>
-                                <Edit className="h-4 w-4 inline mr-1" />
+                            <button className="px-3 py-1.5 rounded border text-sm"
+                                    onClick={() => setEditSchedule(!editSchedule)}>
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editSchedule ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
                         {editSchedule ? (
-                            <>
-                <textarea
-                    defaultValue={data.schedule.map(s => `${s.time}: ${s.activity}`).join("\n")}
-                    rows={data.schedule.length + 2}
-                    className="w-full p-3 rounded border"
-                    placeholder="각 줄에 '시간: 일정' 형식으로 입력"
-                />
-                                <p className="text-sm text-gray-500 mt-1">각 줄에 '시간: 일정' 형식으로 입력하세요.</p>
-                            </>
+                            <div className="space-y-2">
+                                {data.schedule.map((s, i) => (
+                                    <div key={i} className="flex gap-2 items-center">
+                                        <input
+                                            type="text"
+                                            className="border rounded px-2 py-1 w-24"
+                                            value={s.time}
+                                            onChange={(e) => {
+                                                const newSchedule = [...data.schedule];
+                                                newSchedule[i].time = e.target.value;
+                                                setData({...data, schedule: newSchedule});
+                                            }}
+                                        />
+                                        <input
+                                            type="text"
+                                            className="border rounded px-2 py-1 flex-1"
+                                            value={s.activity}
+                                            onChange={(e) => {
+                                                const newSchedule = [...data.schedule];
+                                                newSchedule[i].activity = e.target.value;
+                                                setData({...data, schedule: newSchedule});
+                                            }}
+                                        />
+                                    </div>
+                                ))}
+                                <button
+                                    className="mt-2 px-3 py-1 rounded border text-sm"
+                                    onClick={() => setData({
+                                        ...data,
+                                        schedule: [...data.schedule, {time: "", activity: ""}]
+                                    })}
+                                >
+                                    + 일정 추가
+                                </button>
+                            </div>
                         ) : (
                             <div className="space-y-3">
                                 {data.schedule.map((s, i) => (
@@ -323,31 +473,62 @@ export default function AiGenerateReviewPage() {
                                 ))}
                             </div>
                         )}
+
                     </section>
 
-                    {/* 하이라이트 */}
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <Tag className="h-6 w-6 text-primary" />
+                                <Tag className="h-6 w-6 text-primary"/>
                                 체험 하이라이트
                             </h3>
-                            <button className="px-3 py-1.5 rounded border text-sm" onClick={() => setEditHighlights(!editHighlights)}>
-                                <Edit className="h-4 w-4 inline mr-1" />
+                            <button
+                                className="px-3 py-1.5 rounded border text-sm"
+                                onClick={() => setEditHighlights(!editHighlights)}
+                            >
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editHighlights ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
                         {editHighlights ? (
-                            <textarea
-                                defaultValue={data.highlights.join("\n")}
-                                rows={data.highlights.length + 2}
-                                className="w-full p-3 rounded border"
-                            />
+                            <div className="space-y-2">
+                                {data.highlights.map((h, i) => (
+                                    <div key={i} className="flex gap-2 items-center">
+                                        <input
+                                            type="text"
+                                            className="border rounded px-2 py-1 flex-1"
+                                            value={h}
+                                            onChange={(e) => {
+                                                const newHighlights = [...data.highlights];
+                                                newHighlights[i] = e.target.value;
+                                                setData({...data, highlights: newHighlights});
+                                            }}
+                                        />
+                                        <button
+                                            className="px-2 py-1 bg-red-500 text-white rounded"
+                                            onClick={() => {
+                                                const newHighlights = data.highlights.filter((_, index) => index !== i);
+                                                setData({...data, highlights: newHighlights});
+                                            }}
+                                        >
+                                            삭제
+                                        </button>
+                                    </div>
+                                ))}
+                                <button
+                                    className="mt-2 px-3 py-1 rounded border text-sm"
+                                    onClick={() =>
+                                        setData({...data, highlights: [...data.highlights, ""]})
+                                    }
+                                >
+                                    + 하이라이트 추가
+                                </button>
+                            </div>
                         ) : (
                             <ul className="space-y-2">
                                 {data.highlights.map((h, i) => (
                                     <li key={i} className="flex items-center gap-2">
-                                        <CheckCircle className="h-5 w-5 text-primary" />
+                                        <CheckCircle className="h-5 w-5 text-primary"/>
                                         <span>{h}</span>
                                     </li>
                                 ))}
@@ -359,26 +540,58 @@ export default function AiGenerateReviewPage() {
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <Tag className="h-6 w-6 text-primary" />
+                                <Tag className="h-6 w-6 text-primary"/>
                                 포함 사항
                             </h3>
-                            <button className="px-3 py-1.5 rounded border text-sm" onClick={() => setEditInclusions(!editInclusions)}>
-                                <Edit className="h-4 w-4 inline mr-1" />
+                            <button
+                                className="px-3 py-1.5 rounded border text-sm"
+                                onClick={() => setEditInclusions(!editInclusions)}
+                            >
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editInclusions ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
+
                         {editInclusions ? (
-                            <textarea
-                                defaultValue={data.inclusions.join(", ")}
-                                className="w-full p-3 rounded border"
-                                placeholder="쉼표로 구분하여 입력"
-                            />
+                            <div className="space-y-2">
+                                {data.inclusions.map((inc, i) => (
+                                    <div key={i} className="flex gap-2 items-center">
+                                        <input
+                                            type="text"
+                                            className="border rounded px-2 py-1 flex-1"
+                                            value={inc}
+                                            onChange={(e) => {
+                                                const newInclusions = [...data.inclusions];
+                                                newInclusions[i] = e.target.value;
+                                                setData({ ...data, inclusions: newInclusions });
+                                            }}
+                                        />
+                                        <button
+                                            className="px-2 py-1 bg-red-500 text-white rounded"
+                                            onClick={() => {
+                                                const newInclusions = data.inclusions.filter((_, index) => index !== i);
+                                                setData({ ...data, inclusions: newInclusions });
+                                            }}
+                                        >
+                                            삭제
+                                        </button>
+                                    </div>
+                                ))}
+                                <button
+                                    className="mt-2 px-3 py-1 rounded border text-sm"
+                                    onClick={() =>
+                                        setData({ ...data, inclusions: [...data.inclusions, ""] })
+                                    }
+                                >
+                                    + 포함 사항 추가
+                                </button>
+                            </div>
                         ) : (
                             <div className="flex flex-wrap gap-2">
                                 {data.inclusions.map((inc, i) => (
                                     <span key={i} className="bg-primary text-primary-foreground px-3 py-1 rounded-full text-sm font-medium">
-                    {inc}
-                  </span>
+          {inc}
+        </span>
                                 ))}
                             </div>
                         )}
@@ -388,26 +601,58 @@ export default function AiGenerateReviewPage() {
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <Tag className="h-6 w-6 text-primary" />
+                                <Tag className="h-6 w-6 text-primary"/>
                                 해시태그
                             </h3>
-                            <button className="px-3 py-1.5 rounded border text-sm" onClick={() => setEditHashtags(!editHashtags)}>
-                                <Edit className="h-4 w-4 inline mr-1" />
+                            <button
+                                className="px-3 py-1.5 rounded border text-sm"
+                                onClick={() => setEditHashtags(!editHashtags)}
+                            >
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editHashtags ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
+
                         {editHashtags ? (
-                            <textarea
-                                defaultValue={data.hashtags.join(", ")}
-                                className="w-full p-3 rounded border"
-                                placeholder="쉼표로 구분하여 입력"
-                            />
+                            <div className="space-y-2">
+                                {data.hashtags.map((tag, i) => (
+                                    <div key={i} className="flex gap-2 items-center">
+                                        <input
+                                            type="text"
+                                            className="border rounded px-2 py-1 flex-1"
+                                            value={tag}
+                                            onChange={(e) => {
+                                                const newTags = [...data.hashtags];
+                                                newTags[i] = e.target.value;
+                                                setData({ ...data, hashtags: newTags });
+                                            }}
+                                        />
+                                        <button
+                                            className="px-2 py-1 bg-red-500 text-white rounded"
+                                            onClick={() => {
+                                                const newTags = data.hashtags.filter((_, index) => index !== i);
+                                                setData({ ...data, hashtags: newTags });
+                                            }}
+                                        >
+                                            삭제
+                                        </button>
+                                    </div>
+                                ))}
+                                <button
+                                    className="mt-2 px-3 py-1 rounded border text-sm"
+                                    onClick={() =>
+                                        setData({ ...data, hashtags: [...data.hashtags, ""] })
+                                    }
+                                >
+                                    + 해시태그 추가
+                                </button>
+                            </div>
                         ) : (
                             <div className="flex flex-wrap gap-2">
                                 {data.hashtags.map((t, i) => (
                                     <span key={i} className="bg-secondary text-secondary-foreground px-3 py-1 rounded-full text-sm">
-                    {t}
-                  </span>
+          {t}
+        </span>
                                 ))}
                             </div>
                         )}
@@ -417,31 +662,66 @@ export default function AiGenerateReviewPage() {
                     <section>
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="text-xl font-semibold flex items-center gap-2">
-                                <Users className="h-6 w-6 text-primary" />
+                                <Users className="h-6 w-6 text-primary"/>
                                 담당자 정보
                             </h3>
-                            <button className="px-3 py-1.5 rounded border text-sm" onClick={() => setEditHost(!editHost)}>
-                                <Edit className="h-4 w-4 inline mr-1" />
+                            <button
+                                className="px-3 py-1.5 rounded border text-sm"
+                                onClick={() => setEditHost(!editHost)}
+                            >
+                                <Edit className="h-4 w-4 inline mr-1"/>
                                 {editHost ? "수정 완료" : "수정하기"}
                             </button>
                         </div>
+
                         {editHost ? (
                             <div className="space-y-2">
-                                <input className="border rounded px-2 py-1 w-full" placeholder="이름" defaultValue={data.host.name} />
-                                <input className="border rounded px-2 py-1 w-full" placeholder="전화번호" defaultValue={data.host.phone} />
-                                <input className="border rounded px-2 py-1 w-full" placeholder="이메일" defaultValue={data.host.email} />
-                                <input className="border rounded px-2 py-1 w-full" placeholder="농장명" defaultValue={data.host.farmName} />
+                                <input
+                                    className="border rounded px-2 py-1 w-full"
+                                    placeholder="이름"
+                                    value={data.host.name}
+                                    onChange={(e) =>
+                                        setData({ ...data, host: { ...data.host, name: e.target.value } })
+                                    }
+                                />
+                                <input
+                                    className="border rounded px-2 py-1 w-full"
+                                    placeholder="전화번호"
+                                    value={data.host.phone}
+                                    onChange={(e) =>
+                                        setData({ ...data, host: { ...data.host, phone: e.target.value } })
+                                    }
+                                />
+                                <input
+                                    className="border rounded px-2 py-1 w-full"
+                                    placeholder="이메일"
+                                    value={data.host.email}
+                                    onChange={(e) =>
+                                        setData({ ...data, host: { ...data.host, email: e.target.value } })
+                                    }
+                                />
+                                <input
+                                    className="border rounded px-2 py-1 w-full"
+                                    placeholder="농장명"
+                                    value={data.host.farmName}
+                                    onChange={(e) =>
+                                        setData({ ...data, host: { ...data.host, farmName: e.target.value } })
+                                    }
+                                />
                             </div>
                         ) : (
                             <p>
                                 <span className="font-medium">{data.host.name}</span> ({data.host.farmName})
-                                <br />
-                                <span className="inline-flex items-center gap-1"><Phone className="h-4 w-4" />문의: {data.host.phone}</span>
-                                <br />
+                                <br/>
                                 <span className="inline-flex items-center gap-1">
-                  <Mail className="h-4 w-4" />
-                  <a href={`mailto:${data.host.email}`} className="hover:underline">{data.host.email}</a>
-                </span>
+        <Phone className="h-4 w-4"/>
+        문의: {data.host.phone}
+      </span>
+                                <br/>
+                                <span className="inline-flex items-center gap-1">
+        <Mail className="h-4 w-4"/>
+        <a href={`mailto:${data.host.email}`} className="hover:underline">{data.host.email}</a>
+      </span>
                             </p>
                         )}
                     </section>

--- a/front-end/src/pages/register/generate/AiGeneratePage.tsx
+++ b/front-end/src/pages/register/generate/AiGeneratePage.tsx
@@ -50,24 +50,6 @@ export default function AiGenerateReviewPage() {
         const placeTypeMap: Record<string, string> = { indoor: "실내", outdoor: "실외" };
         const regionTypeMap: Record<string, string> = { rural: "농촌", fishing: "어촌" };
 
-        // selectedClosedDays 정리
-        const rawClosedDays = result.selectedClosedDays || [];
-
-        const cleaned = rawClosedDays.join(",").replace(/[\[\]]/g, "");
-
-        const closedDays = cleaned
-            .split(/(요일)/)          // "요일"을 기준으로 split
-            .map(s => s.trim())       // 공백 제거
-            .filter(s => s !== "")    // 빈 문자열 제거
-            .reduce((acc: string[], curr, idx, arr) => {
-                if (curr === "요일") {
-                    acc[acc.length - 1] += curr; // 이전 값 뒤에 "요일" 붙이기
-                } else if (curr !== ",") {
-                    acc.push(curr);
-                }
-                return acc;
-            }, []);
-
         // scheduleItems 변환
         const schedule = (result.scheduleItems || []).map((s: string) => {
             const [time, ...rest] = s.split("-");
@@ -84,9 +66,9 @@ export default function AiGenerateReviewPage() {
             crops: result.crops,
             price: String(result.price),
             duration: "약 " + result.duration + "시간", // 운영 시간은 추후 입력
-            availableDates: closedDays,
+            availableDates: result.selectedClosedDays ,
             operatingHours: `${result.startTime || ""} - ${result.endTime || ""}`,
-            closedDays: closedDays,
+            closedDays: result.selectedClosedDays ,
             minParticipants: result.minParticipants,
             maxParticipants: result.maxParticipants,
             schedule,
@@ -234,8 +216,12 @@ export default function AiGenerateReviewPage() {
                                 </div>
                                 <div
                                     className="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-50 text-gray-700">
-                                    <Calendar className="h-6 w-6 mb-2"/><span
-                                    className="font-medium">{data.availableDates}</span>
+                                    <Calendar className="h-6 w-6 mb-2"/>
+                                    <span className="font-medium">
+        {Array.isArray(data.availableDates)
+            ? data.availableDates.join(", ")  // 배열이면 ,로 연결
+            : data.availableDates.split(/[,]/).join(", ")} {/* 문자열이면 , 기준으로 split */}
+    </span>
                                 </div>
                             </div>
                         )}

--- a/front-end/src/pages/register/generate/AiGeneratePage.tsx
+++ b/front-end/src/pages/register/generate/AiGeneratePage.tsx
@@ -8,29 +8,12 @@ import {
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
-// (임시) 등록 API — 나중에 실제 백엔드 연동으로 교체
-async function registerExperience(payload: unknown): Promise<{success:boolean; message:string}> {
-    try {
-        // 실제 연동 시:
-        // const res = await fetch(`${process.env.REACT_APP_API_URL}/experiences`, {
-        //   method: "POST",
-        //   headers: { "Content-Type": "application/json" },
-        //   body: JSON.stringify(payload),
-        // });
-        // if (!res.ok) return { success: false, message: await res.text() };
-        // return { success: true, message: "등록 완료!" };
-
-        console.log("mock registerExperience payload:", payload);
-        return { success: true, message: "(mock) 등록 완료!" };
-    } catch (e: any) {
-        return { success: false, message: e?.message ?? "알 수 없는 오류" };
-    }
-}
+const API_BASE = "http://localhost:8080/api/v1/experience"
 
 type ScheduleItem = { time: string; activity: string };
 type ExperienceData = {
     title: string;
-    aiPromotionalText: string;
+    description: string;
     location: string;
     address: string;
     placeType: string;
@@ -49,50 +32,6 @@ type ExperienceData = {
     hashtags: string[];
     host: { name: string; phone: string; email: string; farmName: string };
     imageUrl?: string;
-};
-
-const initialData: ExperienceData = {
-    title: "AI 추천: 숲속 힐링 명상 & 차담 체험 🧘‍♀️🍵",
-    aiPromotionalText: `바쁜 일상에 지친 당신을 위한 완벽한 휴식! 🌿
-고요한 숲속에서 자연의 소리를 들으며 깊은 명상에 잠기고,
-향긋한 전통차와 함께 마음을 나누는 차담 시간을 가져보세요.
-몸과 마음의 균형을 되찾고, 새로운 에너지를 충전할 수 있습니다.
-도심을 벗어나 진정한 나를 만나는 특별한 경험을 선사합니다.`,
-    location: "경기도 가평",
-    address: "가평군 상면 수목원로 123",
-    placeType: "실외",
-    regionType: "농촌",
-    crops: "차, 허브",
-    price: "45,000원",
-    duration: "약 2시간",
-    availableDates: "매주 주말 (사전 예약 필수)",
-    operatingHours: "10:00 - 17:00",
-    closedDays: ["월요일", "공휴일"],
-    minParticipants: 1,
-    maxParticipants: 10,
-    schedule: [
-        { time: "10:00", activity: "✅ 농장 도착 및 환영" },
-        { time: "10:30", activity: "🛠️ 명상 도구 설명 및 안전 교육" },
-        { time: "11:00", activity: "🧘‍♀️ 숲속 명상 체험" },
-        { time: "12:00", activity: "🍽️ 전통차 시음 및 다과" },
-        { time: "12:30", activity: "🗣️ 자유로운 차담 시간" },
-        { time: "13:00", activity: "👋 체험 마무리 및 기념품 증정" },
-    ],
-    highlights: [
-        "전문가와 함께하는 숲속 명상",
-        "다도 체험 및 전통차 시음",
-        "자연 속에서 얻는 깊은 평화와 안정",
-        "소규모 그룹으로 프라이빗한 경험",
-    ],
-    inclusions: ["명상 도구 대여", "전통차 및 다과", "전문가 가이드", "기념품"],
-    hashtags: ["#숲속명상", "#차담", "#힐링체험", "#자연치유", "#가평여행"],
-    host: {
-        name: "김철수",
-        phone: "010-1234-5678",
-        email: "kim.chulsoo@example.com",
-        farmName: "가평 힐링 숲 농장",
-    },
-    imageUrl: "/placeholder.svg?height=400&width=600",
 };
 
 export default function AiGenerateReviewPage() {
@@ -137,7 +76,7 @@ export default function AiGenerateReviewPage() {
 
         return {
             title: result.title,
-            aiPromotionalText: result.description || "",
+            description: result.description || "",
             location: result.region,
             address: result.address,
             placeType: placeTypeMap[result.placeType] || "실내",
@@ -167,7 +106,7 @@ export default function AiGenerateReviewPage() {
 
     // 편집 토글
     const [editPromo, setEditPromo] = useState(false);
-    const [promoText, setPromoText] = useState(data.aiPromotionalText);
+    const [promoText, setPromoText] = useState(data.description);
     const [editBasic, setEditBasic] = useState(false);
     const [editDetails, setEditDetails] = useState(false);
     const [editSchedule, setEditSchedule] = useState(false);
@@ -180,23 +119,20 @@ export default function AiGenerateReviewPage() {
         try {
             setIsSubmitting(true);
 
-            // payload 구성: data + aiPromotionalText 포함
-            const payload = { ...data, aiPromotionalText: promoText };
-
-            const response = await fetch("/api/v1/test", {
+            const response = await fetch(API_BASE, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
                 },
-                body: JSON.stringify(payload),
+                body: JSON.stringify(data),
             });
 
             if (!response.ok) throw new Error("등록 실패");
 
-            const result = await response.json();
-
-            // alert 출력
-            alert(`${result.success ? "✅" : "❌"} ${result.message}`);
+            // const result = await response.json();
+            //
+            // // alert 출력
+            // alert(`${result.success ? "✅" : "❌"} ${result.message}`);
         } catch (error) {
             console.error(error);
             alert("❌ 등록 실패. 다시 시도해주세요.");

--- a/front-end/src/pages/register/generate/onboarding/GenerateOnboardingPage.tsx
+++ b/front-end/src/pages/register/generate/onboarding/GenerateOnboardingPage.tsx
@@ -179,13 +179,11 @@ export default function GenerateOnboardingPage() {
             const result = await response.json();
             console.log("서버 응답:", result);
 
-            // navigate("/register/ai-generate/review");
+            navigate("/register/ai-generate",  { state: { result } });
         } catch (error) {
             console.error("요청 실패:", error);
             alert("서버와 통신 중 오류가 발생했습니다.");
         }
-
-        // navigate("/register/ai-generate/review");
     };
 
     const Step = () => {


### PR DESCRIPTION
 AI 체험 온보딩 결과 화면을 화면에 렌더링하도록 구현
- 기본 정보(위치, 기간, 가격, 이용 가능 날짜) 표시 및 수정 기능 추가
  - 수정 모드 시 input 필드로 변경 가능
  - 이용 가능 날짜는 요일 단위로 배열 처리 후 ,로 구분하여 표시
- 수정 완료/수정하기 버튼 클릭 시 상태 변경 및 데이터 반영
- UI 개선: Tailwind CSS 활용, 아이콘과 텍스트 정렬 및 카드 형태 디자인 적용
- Experience 속성 전부 수정


- 체험 등록 시 하이라이트, 포함 사항, 해시태크도 추출하도록 프롬포트 개선
- 양식을 만들어서 오류없이 정상 동작 확인