### PR TITLE
<Experience > 온보딩 과정 및 등록 기능 구현

### DIFF
--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
@@ -30,7 +30,6 @@ public class ExperienceController {
 
 	@PostMapping
 	public ResponseEntity<?> registerExperience(@RequestBody ExpRegisterDto dto){
-
 		experienceService.registerExperience(dto);
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpRegisterDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpRegisterDto.java
@@ -2,12 +2,14 @@ package com.onnongwa.back_end.domain.experience.controller.dto;
 
 import java.util.List;
 
+import com.onnongwa.back_end.domain.experience.entity.ExperienceSchedule;
+
 public record ExpRegisterDto(
 	// 기본 정보
 	String title,
 	String location,
 	String duration,
-	String price,
+	Integer price,
 	List<String> availableDates,
 	String description,
 	String imageUrl,
@@ -23,7 +25,7 @@ public record ExpRegisterDto(
 	int maxParticipants,
 
 	// 일정
-	List<ScheduleItem> schedule,
+	List<ScheduleDto> schedule,
 
 	// 하이라이트
 	List<String> highlights,
@@ -38,7 +40,8 @@ public record ExpRegisterDto(
 	HostInfo host
 
 ) {
-	public record ScheduleItem(
+
+	public record ScheduleDto(
 		String time,
 		String activity
 	) {}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpRegisterDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpRegisterDto.java
@@ -2,8 +2,6 @@ package com.onnongwa.back_end.domain.experience.controller.dto;
 
 import java.util.List;
 
-import com.onnongwa.back_end.domain.experience.entity.ExperienceSchedule;
-
 public record ExpRegisterDto(
 	// 기본 정보
 	String title,

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
@@ -3,6 +3,7 @@ package com.onnongwa.back_end.domain.experience.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
 import com.onnongwa.back_end.domain.farm.entity.Farm;
 import jakarta.persistence.*;
 import lombok.*;
@@ -75,6 +76,42 @@ public class Experience {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "farm_id", nullable = false)
     private Farm farm;
+
+
+    public static Experience from(ExpRegisterDto dto, Farm farm){
+        Experience experience = Experience.builder()
+            .title(dto.title())
+            .description(dto.description())
+            .location(dto.location())
+            .duration(dto.duration())
+            .price(dto.price())
+            .address(dto.address())
+            .placeType(dto.placeType())
+            .regionType(dto.regionType())
+            .crops(dto.crops())
+            .operatingHours(dto.operatingHours())
+            .minParticipants(dto.minParticipants())
+            .maxParticipants(dto.maxParticipants())
+            .imageUrl(dto.imageUrl())
+            .closedDays(dto.closedDays())
+            .highlights(dto.highlights())
+            .inclusions(dto.inclusions())
+            .hashtags(dto.hashtags())
+            .hostName(dto.host().name())
+            .hostPhone(dto.host().phone())
+            .hostEmail(dto.host().email())
+            .hostFarmName(dto.host().farmName())
+            .farm(farm)
+            .build();
+
+        // 스케줄 추가
+        dto.schedule().forEach(s -> {
+            ExperienceSchedule schedule = new ExperienceSchedule(s.time(), s.activity());
+            experience.addSchedule(schedule);
+        });
+
+        return experience;
+    }
 
 
     public void addSchedule(ExperienceSchedule schedule) {

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
@@ -61,19 +61,25 @@ public class Experience {
     @Column(name = "hashtag")
     private List<String> hashtags = new ArrayList<>();
 
+    // 일정
+    @OneToMany(mappedBy = "experience", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ExperienceSchedule> schedule = new ArrayList<>();
+
     // 담당자 정보 (Host)
     private String hostName;
     private String hostPhone;
     private String hostEmail;
     private String hostFarmName;
 
-    // 관계
-
-    // 일정
-    @OneToMany(mappedBy = "experience", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ExperienceSchedule> schedule = new ArrayList<>();
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "farm_id", nullable = false)
     private Farm farm;
+
+
+    public void addSchedule(ExperienceSchedule schedule) {
+        this.schedule.add(schedule);
+        schedule.setExperience(this);
+    }
+
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/ExperienceSchedule.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/ExperienceSchedule.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,14 @@ public class ExperienceSchedule {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "experience_id")
 	private Experience experience;
+
+	public ExperienceSchedule(String time, String activity, Experience experience) {
+		this.time = time;
+		this.activity = activity;
+		this.experience = experience;
+	}
+
+	public void setExperience(Experience experience) {
+		this.experience = experience;
+	}
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/ExperienceSchedule.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/ExperienceSchedule.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,13 +26,12 @@ public class ExperienceSchedule {
 	@JoinColumn(name = "experience_id")
 	private Experience experience;
 
-	public ExperienceSchedule(String time, String activity, Experience experience) {
+	public ExperienceSchedule(String time, String activity) {
 		this.time = time;
 		this.activity = activity;
-		this.experience = experience;
 	}
 
-	public void setExperience(Experience experience) {
+	void setExperience(Experience experience) {
 		this.experience = experience;
 	}
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/repository/ExperienceRepository.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/repository/ExperienceRepository.java
@@ -1,0 +1,8 @@
+package com.onnongwa.back_end.domain.experience.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.onnongwa.back_end.domain.experience.entity.Experience;
+
+public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
@@ -19,6 +20,7 @@ import com.onnongwa.back_end.domain.farm.entity.Farm;
 import com.onnongwa.back_end.domain.farm.repository.FarmRepository;
 import com.onnongwa.back_end.open_api.service.OpenApiService;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -31,42 +33,12 @@ public class ExperienceService {
 	private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
 	private final String IMAGE_BASE_URL = "/uploads/";
 
+	@Transactional
 	public void registerExperience(ExpRegisterDto dto){
 
-		Farm farm = farmRepository.findById(1L).orElseThrow();
+		Farm farm = farmRepository.findById(1L).orElseThrow(() -> new EntityNotFoundException("Farm not found with id : 1L"));
 
-		Experience experience = Experience.builder()
-			.title(dto.title())
-			.description(dto.description())
-			.location(dto.location())
-			.duration(dto.duration())
-			.price(dto.price())
-			.address(dto.address())
-			.placeType(dto.placeType())
-			.regionType(dto.regionType())
-			.crops(dto.crops())
-			.operatingHours(dto.operatingHours())
-			.minParticipants(dto.minParticipants())
-			.maxParticipants(dto.maxParticipants())
-			.imageUrl(dto.imageUrl())
-			.closedDays(dto.closedDays())
-			.highlights(dto.highlights())
-			.inclusions(dto.inclusions())
-			.hashtags(dto.hashtags())
-			.hostName(dto.host().name())
-			.hostPhone(dto.host().phone())
-			.hostEmail(dto.host().email())
-			.hostFarmName(dto.host().farmName())
-			.farm(farm)
-			.build();
-
-		// 스케줄 추가
-		dto.schedule().forEach(s -> {
-			ExperienceSchedule schedule = new ExperienceSchedule(s.time(), s.activity(), experience);
-			experience.addSchedule(schedule);
-		});
-
-		experienceRepository.save(experience);
+		experienceRepository.save(Experience.from(dto,farm));
 	}
 
 	public String saveImageAndGetUrl(MultipartFile file) throws IOException{

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
@@ -5,12 +5,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
+import com.onnongwa.back_end.domain.experience.entity.Experience;
+import com.onnongwa.back_end.domain.experience.entity.ExperienceSchedule;
+import com.onnongwa.back_end.domain.experience.repository.ExperienceRepository;
+import com.onnongwa.back_end.domain.farm.entity.Farm;
+import com.onnongwa.back_end.domain.farm.repository.FarmRepository;
 import com.onnongwa.back_end.open_api.service.OpenApiService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,11 +25,48 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ExperienceService {
 
+	private final ExperienceRepository experienceRepository;
+	private final FarmRepository farmRepository;
+
 	private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
 	private final String IMAGE_BASE_URL = "/uploads/";
 
 	public void registerExperience(ExpRegisterDto dto){
 
+		Farm farm = farmRepository.findById(1L).orElseThrow();
+
+		Experience experience = Experience.builder()
+			.title(dto.title())
+			.description(dto.description())
+			.location(dto.location())
+			.duration(dto.duration())
+			.price(dto.price())
+			.address(dto.address())
+			.placeType(dto.placeType())
+			.regionType(dto.regionType())
+			.crops(dto.crops())
+			.operatingHours(dto.operatingHours())
+			.minParticipants(dto.minParticipants())
+			.maxParticipants(dto.maxParticipants())
+			.imageUrl(dto.imageUrl())
+			.closedDays(dto.closedDays())
+			.highlights(dto.highlights())
+			.inclusions(dto.inclusions())
+			.hashtags(dto.hashtags())
+			.hostName(dto.host().name())
+			.hostPhone(dto.host().phone())
+			.hostEmail(dto.host().email())
+			.hostFarmName(dto.host().farmName())
+			.farm(farm)
+			.build();
+
+		// 스케줄 추가
+		dto.schedule().forEach(s -> {
+			ExperienceSchedule schedule = new ExperienceSchedule(s.time(), s.activity(), experience);
+			experience.addSchedule(schedule);
+		});
+
+		experienceRepository.save(experience);
 	}
 
 	public String saveImageAndGetUrl(MultipartFile file) throws IOException{


### PR DESCRIPTION
- `/api/v1/experience` 경로의 Post 요청을 처리
- ExpRegisterDto → Experience 변환 및 저장 로직 구현
- 일정(schedule)은 ExperienceSchedule 엔티티로 관리 (연관관계 편의 메서드 사용)
- 그 외 세부 요소(closedDays, highlights, inclusions, hashtags)는 @ElementCollection으로 테이블 분리 저장
- Cascade 옵션으로 Experience 저장 시 관련 데이터 자동 저장
- 현재는 farmId = 1L 고정 (유저 식별 기능 구현 시 수정 예정)