### PR TITLE
<Experience> 체험 상세보기 및 메인화면 추천 체험 기능 구현

### DIFF
--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,7 +33,22 @@ public class ExperienceController {
 	@PostMapping
 	public ResponseEntity<?> registerExperience(@RequestBody ExpRegisterDto dto){
 		experienceService.registerExperience(dto);
-		return ResponseEntity.status(HttpStatus.OK).build();
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.build();
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<?> getExperienceById(@PathVariable("id") Long id ){
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(experienceService.getExperienceById(id));
+	}
+
+	@GetMapping("/popular")
+	public ResponseEntity<?> getTop3ExperiencesByViewCount() {
+		experienceService.getTop3ExperiencesByViewCount();
+		return null;
 	}
 
 	@PostMapping("/onboarding")

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
@@ -47,8 +47,8 @@ public class ExperienceController {
 
 	@GetMapping("/popular")
 	public ResponseEntity<?> getTop3ExperiencesByViewCount() {
-		experienceService.getTop3ExperiencesByViewCount();
-		return null;
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(experienceService.getTop3ExperiencesByViewCount());
 	}
 
 	@PostMapping("/onboarding")

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpDetailDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpDetailDto.java
@@ -1,0 +1,33 @@
+package com.onnongwa.back_end.domain.experience.controller.dto;
+
+import java.util.List;
+
+public record ExpDetailDto(
+	String title,
+	String region,
+	String address,
+	String placeType,
+	String regionType,
+	String description,
+	String crops,
+	String price,
+	List<ScheduleItemDTO> scheduleItems,
+	String startTime,
+	String endTime,
+	List<String> selectedClosedDays,
+	int minParticipants,
+	int maxParticipants,
+	Host host,
+	String imageUrl,
+	int viewCount
+) {
+	public record ScheduleItemDTO(
+		String time,
+		String activity
+	) {}
+	public record Host(
+		String hostName,
+		String hostPhone,
+		String hostEmail,
+		String farmName) {}
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpDetailDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpDetailDto.java
@@ -3,31 +3,46 @@ package com.onnongwa.back_end.domain.experience.controller.dto;
 import java.util.List;
 
 public record ExpDetailDto(
+	// 기본 정보
 	String title,
 	String region,
+	String description,
+	String price,
+	String imageUrl,
+	int viewCount,
+
+	// 상세 정보
 	String address,
 	String placeType,
 	String regionType,
-	String description,
 	String crops,
-	String price,
-	List<ScheduleItemDTO> scheduleItems,
 	String startTime,
 	String endTime,
 	List<String> selectedClosedDays,
 	int minParticipants,
 	int maxParticipants,
-	Host host,
-	String imageUrl,
-	int viewCount
+
+	// 일정
+	List<ScheduleItemDTO> scheduleItems,
+
+	List<String> highlights,
+
+	List<String> inclusions,
+
+	List<String> hashtags,
+
+	// 운영자 정보
+	Host host
 ) {
 	public record ScheduleItemDTO(
 		String time,
 		String activity
 	) {}
+
 	public record Host(
 		String hostName,
 		String hostPhone,
 		String hostEmail,
-		String farmName) {}
+		String farmName
+	) {}
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpListDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpListDto.java
@@ -1,0 +1,14 @@
+package com.onnongwa.back_end.domain.experience.controller.dto;
+
+import java.util.List;
+
+public record ExpListDto(
+	Long id,
+	String imageUrl,
+	String title,
+	String description,
+	String location,
+	int price,
+	List<String> hashTag
+) {
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpDetailDto;
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpListDto;
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
 import com.onnongwa.back_end.domain.farm.entity.Farm;
 import jakarta.persistence.*;
@@ -115,35 +116,56 @@ public class Experience {
         return experience;
     }
 
-    public ExpDetailDto toDto() {
+    public ExpDetailDto toDetailDto() {
         return new ExpDetailDto(
+            // 기본 정보
             this.title,
-            this.location,   // region → location
+            this.location, // Experience 엔티티의 location 필드가 DTO의 region에 해당
+            this.description,
+            String.valueOf(this.price), // int -> String 변환
+            this.imageUrl,
+            this.viewCount,
+
+            // 상세 정보
             this.address,
             this.placeType,
             this.regionType,
-            this.description,
             this.crops,
-            String.valueOf(this.price),   // int → String 변환
-            this.schedule.stream()
-                .map(s -> new ExpDetailDto.ScheduleItemDTO(s.getTime(), s.getActivity()))
-                .toList(),
-            this.operatingHours.split("-")[0].trim(), // startTime
-            this.operatingHours.split("-")[1].trim(), // endTime
+            this.operatingHours.split("-")[0].trim(), // "09:00 - 18:00" -> "09:00"
+            this.operatingHours.split("-")[1].trim(), // "09:00 - 18:00" -> "18:00"
             this.closedDays,
             this.minParticipants,
             this.maxParticipants,
+
+            // 일정
+            this.schedule.stream()
+                .map(s -> new ExpDetailDto.ScheduleItemDTO(s.getTime(), s.getActivity()))
+                .toList(),
+
+            this.highlights,
+            this.inclusions,
+            this.hashtags,
+
+            // 운영자 정보
             new ExpDetailDto.Host(
                 this.hostName,
                 this.hostPhone,
                 this.hostEmail,
                 this.hostFarmName
-            ),
-            this.imageUrl,
-            this.viewCount
+            )
         );
+    }
 
-
+    public ExpListDto toListDto(){
+        return new ExpListDto(
+            this.id,
+            this.imageUrl,
+            this.title,
+            this.description,
+            this.location,
+            this.price,
+            this.hashtags
+        );
     }
 
     public void addSchedule(ExperienceSchedule schedule) {

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
@@ -3,6 +3,7 @@ package com.onnongwa.back_end.domain.experience.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpDetailDto;
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
 import com.onnongwa.back_end.domain.farm.entity.Farm;
 import jakarta.persistence.*;
@@ -112,6 +113,37 @@ public class Experience {
         });
 
         return experience;
+    }
+
+    public ExpDetailDto toDto() {
+        return new ExpDetailDto(
+            this.title,
+            this.location,   // region → location
+            this.address,
+            this.placeType,
+            this.regionType,
+            this.description,
+            this.crops,
+            String.valueOf(this.price),   // int → String 변환
+            this.schedule.stream()
+                .map(s -> new ExpDetailDto.ScheduleItemDTO(s.getTime(), s.getActivity()))
+                .toList(),
+            this.operatingHours.split("-")[0].trim(), // startTime
+            this.operatingHours.split("-")[1].trim(), // endTime
+            this.closedDays,
+            this.minParticipants,
+            this.maxParticipants,
+            new ExpDetailDto.Host(
+                this.hostName,
+                this.hostPhone,
+                this.hostEmail,
+                this.hostFarmName
+            ),
+            this.imageUrl,
+            this.viewCount
+        );
+
+
     }
 
     public void addSchedule(ExperienceSchedule schedule) {

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
@@ -32,11 +32,11 @@ public class Experience {
 
     // 운영 정보
     private String operatingHours;  // 운영 시간 (ex: "09:00 - 18:00")
-
     private int minParticipants;    // 최소 인원
     private int maxParticipants;    // 최대 인원
-
     private String imageUrl;        // 대표 이미지 URL
+
+    private int viewCount; // 조회수
 
     @ElementCollection
     @CollectionTable(name = "experience_closed_days", joinColumns = @JoinColumn(name = "experience_id"))
@@ -93,6 +93,7 @@ public class Experience {
             .minParticipants(dto.minParticipants())
             .maxParticipants(dto.maxParticipants())
             .imageUrl(dto.imageUrl())
+            .viewCount(0)
             .closedDays(dto.closedDays())
             .highlights(dto.highlights())
             .inclusions(dto.inclusions())
@@ -113,10 +114,13 @@ public class Experience {
         return experience;
     }
 
-
     public void addSchedule(ExperienceSchedule schedule) {
         this.schedule.add(schedule);
         schedule.setExperience(this);
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
     }
 
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/repository/ExperienceRepository.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/repository/ExperienceRepository.java
@@ -1,8 +1,15 @@
 package com.onnongwa.back_end.domain.experience.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.onnongwa.back_end.domain.experience.entity.Experience;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+
+	@Query(value = "SELECT * FROM experience ORDER BY view_count DESC LIMIT 3", nativeQuery = true)
+	List<Experience> findTop3ByViewCount();
+
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,19 +51,20 @@ public class ExperienceService {
 
 		experience.increaseViewCount();
 
-		return experience.toDto();
+		return experience.toDetailDto();
 	}
 
 
-	public void getTop3ExperiencesByViewCount() {
+	public List<ExpListDto> getTop3ExperiencesByViewCount() {
 
 		List<Experience> top3s = experienceRepository.findTop3ByViewCount();
 
-
+		List<ExpListDto> dtos = new ArrayList<>();
 		for(Experience e: top3s){
-			System.out.println(e.getTitle());
+			dtos.add(e.toListDto());
 		}
 
+		return dtos;
 	}
 
 	public String saveImageAndGetUrl(MultipartFile file) throws IOException{

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpDetailDto;
+import com.onnongwa.back_end.domain.experience.controller.dto.ExpListDto;
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
 import com.onnongwa.back_end.domain.experience.entity.Experience;
 import com.onnongwa.back_end.domain.experience.entity.ExperienceSchedule;
@@ -41,6 +43,28 @@ public class ExperienceService {
 		experienceRepository.save(Experience.from(dto,farm));
 	}
 
+	@Transactional
+	public ExpDetailDto getExperienceById(Long id) {
+		Experience experience = experienceRepository.findById(id)
+			.orElseThrow(() ->  new EntityNotFoundException(  "Farm not found with id : " + id));
+
+		experience.increaseViewCount();
+
+		return experience.toDto();
+	}
+
+
+	public void getTop3ExperiencesByViewCount() {
+
+		List<Experience> top3s = experienceRepository.findTop3ByViewCount();
+
+
+		for(Experience e: top3s){
+			System.out.println(e.getTitle());
+		}
+
+	}
+
 	public String saveImageAndGetUrl(MultipartFile file) throws IOException{
 		if (file.isEmpty()){
 			throw new IllegalAccessError("이미지가 존재하지 않습니다.");
@@ -58,10 +82,8 @@ public class ExperienceService {
 
 		Files.copy(file.getInputStream(), path, StandardCopyOption.REPLACE_EXISTING);
 
-		System.out.println(IMAGE_BASE_URL + savedFileName);
-
-
 		return IMAGE_BASE_URL + savedFileName;
 	}
+
 
 }

--- a/front-end/src/pages/experience/ExperienceDetailPage.tsx
+++ b/front-end/src/pages/experience/ExperienceDetailPage.tsx
@@ -1,10 +1,41 @@
-// 체험 상세
+import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import {
     MapPin, Tag, Calendar, Users, Clock, Star,
     CheckCircle, Compass, Activity, TreePine, PartyPopper, Mail
 } from "lucide-react";
 
+// API 응답 데이터의 타입을 정의합니다. (highlights, inclusions, hashtags 추가)
+type ApiScheduleItem = {
+    time: string;
+    activity: string;
+};
+
+type ApiHost = {
+    hostName: string;
+    hostPhone: string;
+    hostEmail: string;
+    farmName: string;
+};
+
+type ApiExperience = {
+    title: string;
+    region: string;
+    description: string;
+    price: string;
+    imageUrl: string;
+    startTime: string;
+    endTime: string;
+    selectedClosedDays: string[];
+    scheduleItems: ApiScheduleItem[];
+    highlights: string[];
+    inclusions: string[];
+    hashtags: string[];
+    host: ApiHost;
+};
+
+
+// 컴포넌트에서 사용할 데이터 타입을 정의합니다.
 type ScheduleItem = { time: string; activity: string };
 type NearbyPlace = { name: string; description: string; image?: string; category: string; link: string };
 
@@ -15,53 +46,73 @@ const categoryIcons: Record<string, React.ComponentType<{ className?: string }>>
 };
 
 export default function ExperienceDetailPage() {
-    const { id } = useParams(); // /experiences/:id
+    const { id } = useParams<{ id: string }>();
 
-    const experience = {
-        id: id ?? "potato-farm",
-        title: "땅속 보물 찾기, 아이와 함께하는 감자 명상 🍠",
-        description: `“평창 감자 힐링 팜” – 땅과 마음을 채우는 특별한 하루 🥔✨
-                        강원도 평창의 깨끗한 들판에서 펼쳐지는 프리미엄 감자 수확 체험. 👨‍👩‍👧‍👦
-                        아이들과 함께 흙 속 깊이 숨은 ‘자연의 보물’을 찾아내며,
-                        수확의 설렘과 자연의 고마움을 온몸으로 느껴보세요. 🌿🤲
-                        감자를 캐는 동안 고요한 바람과 흙 내음을 만끽하는 ‘감자 명상’ 시간이 준비되어 있습니다. 🧘‍♀️🌬️
-                        일상의 복잡함을 내려놓고, 오롯이 현재에 머무는 순간을 경험하세요. 😌
-                        수확한 감자는 그대로 가져갈 수 있으며,
-                        현장에서 갓 캔 감자로 만든 따끈한 간식도 맛볼 수 있습니다. 😋
-                        가족, 친구, 연인과 함께하는 평창 감자 힐링 팜에서
-                        평생 기억될 하루를 만들어보세요. ❤️`,
-        location: "강원도 평창",
-        price: "50,000원",
-        hashtags: ["#감자캐기", "#가족여행", "#농촌체험", "#힐링", "#자연교감", "#평창"],
-        image: "/placeholder.svg?height=400&width=600",
-        host: {
-            name: "평창 감자 농장",
-            contact: "010-1234-5678",
-            email: "potato.farm@example.com",
-        },
-        duration: "약 3시간",
-        availableDates: "매주 주말 (사전 예약 필수)",
-        schedule: [
-            { time: "10:00", activity: "✅ 농장 도착 및 환영" },
-            { time: "10:30", activity: "🛠️ 감자 캐기 도구 설명 및 안전 교육" },
-            { time: "11:00", activity: "🥔 본격적인 감자 캐기 체험 (땅속 보물 찾기)" },
-            { time: "12:00", activity: "🍽️ 수확한 감자로 만든 간식 시식 및 휴식" },
-            { time: "12:30", activity: "🧘‍♀️ 감자 명상 시간 및 자유 시간" },
-            { time: "13:00", activity: "👋 체험 마무리 및 기념품 증정" },
-        ] as ScheduleItem[],
-        highlights: [
-            "아이들이 좋아하는 땅속 보물 찾기 컨셉",
-            "청정 자연 속에서 즐기는 힐링 명상",
-            "갓 캔 유기농 감자로 만든 특별한 간식",
-            "직접 수확한 감자 가져가기",
-        ],
-        inclusions: ["체험 도구 대여", "수확 감자 (1kg)", "감자 간식", "안전 교육"],
-        nearbyPlaces: [
-            { name: "대관령 양떼목장", description: "푸른 초원에서 양들과 교감하는 목장 체험.", image: "/placeholder.svg?height=150&width=250", category: "activity", link: "#" },
-            { name: "월정사 전나무 숲길", description: "천년 고찰 월정사의 고요한 전나무 숲길을 거닐며 힐링.", image: "/placeholder.svg?height=150&width=250", category: "nature", link: "#" },
-            { name: "평창 송어축제장", description: "겨울철 얼음낚시와 다양한 즐길 거리가 가득한 축제.", image: "/placeholder.svg?height=150&width=250", category: "festival", link: "#" },
-        ] as NearbyPlace[],
-    };
+    // 서버 데이터, 로딩 상태, 에러 상태를 관리합니다.
+    const [experience, setExperience] = useState<any>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!id) return;
+
+        const fetchExperienceData = async () => {
+            try {
+                setLoading(true);
+                // API 서버로 데이터 요청
+                const response = await fetch(`http://localhost:8080/api/v1/experience/${id}`);
+                if (!response.ok) {
+                    throw new Error('체험 정보를 불러오는데 실패했습니다.');
+                }
+                const data: ApiExperience = await response.json();
+
+                // API 데이터를 컴포넌트 형식에 맞게 변환
+                const formattedData = {
+                    title: data.title,
+                    description: data.description,
+                    location: data.region,
+                    price: `${parseInt(data.price).toLocaleString()}원`,
+                    image: data.imageUrl,
+                    host: {
+                        name: data.host.farmName,
+                        contact: data.host.hostPhone,
+                        email: data.host.hostEmail,
+                    },
+                    duration: `약 ${parseInt(data.endTime) - parseInt(data.startTime)}시간`,
+                    availableDates: `${data.selectedClosedDays.join(', ')} 휴무`,
+                    schedule: data.scheduleItems,
+                    // API에서 직접 받은 데이터 사용
+                    highlights: data.highlights,
+                    inclusions: data.inclusions,
+                    hashtags: data.hashtags,
+                    nearbyPlaces: [], // 이 부분은 API에 없으므로 그대로 둡니다.
+                };
+
+                setExperience(formattedData);
+            } catch (err: any) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchExperienceData();
+    }, [id]); // id가 바뀔 때마다 다시 데이터를 요청합니다.
+
+    // 로딩 중일 때 표시할 화면
+    if (loading) {
+        return <div className="flex justify-center items-center h-screen">로딩 중...</div>;
+    }
+
+    // 에러 발생 시 표시할 화면
+    if (error) {
+        return <div className="flex justify-center items-center h-screen text-red-500">오류: {error}</div>;
+    }
+
+    // 데이터가 없을 때 표시할 화면
+    if (!experience) {
+        return <div className="flex justify-center items-center h-screen">해당 체험을 찾을 수 없습니다.</div>;
+    }
 
     return (
         <>
@@ -108,7 +159,7 @@ export default function ExperienceDetailPage() {
                             체험 일정
                         </h3>
                         <div className="space-y-3">
-                            {experience.schedule.map((item, idx) => (
+                            {experience.schedule.map((item: ScheduleItem, idx: number) => (
                                 <div key={idx} className="flex items-start gap-3 p-3 bg-background rounded-md shadow-sm">
                                     <span className="font-semibold w-16 flex-shrink-0">{item.time}</span>
                                     <span>{item.activity}</span>
@@ -124,7 +175,7 @@ export default function ExperienceDetailPage() {
                             체험 하이라이트
                         </h3>
                         <ul className="space-y-2">
-                            {experience.highlights.map((h, idx) => (
+                            {experience.highlights.map((h: string, idx: number) => (
                                 <li key={idx} className="flex items-center gap-2">
                                     <CheckCircle className="h-5 w-5 text-primary flex-shrink-0" />
                                     <span>{h}</span>
@@ -140,10 +191,10 @@ export default function ExperienceDetailPage() {
                             포함 사항
                         </h3>
                         <div className="flex flex-wrap gap-2">
-                            {experience.inclusions.map((inc, idx) => (
+                            {experience.inclusions.map((inc: string, idx: number) => (
                                 <span key={idx} className="bg-primary text-primary-foreground px-3 py-1 rounded-full text-sm font-medium">
-                  {inc}
-                </span>
+                                    {inc}
+                                </span>
                             ))}
                         </div>
                     </div>
@@ -155,10 +206,10 @@ export default function ExperienceDetailPage() {
                             해시태그
                         </h3>
                         <div className="flex flex-wrap gap-2">
-                            {experience.hashtags.map((tag, idx) => (
+                            {experience.hashtags.map((tag: string, idx: number) => (
                                 <span key={idx} className="bg-secondary text-secondary-foreground px-3 py-1 rounded-full text-sm">
-                  {tag}
-                </span>
+                                    {tag}
+                                </span>
                             ))}
                         </div>
                     </div>
@@ -177,53 +228,35 @@ export default function ExperienceDetailPage() {
                                 <>
                                     <br />
                                     <span className="inline-flex items-center gap-1">
-                    <Mail className="h-4 w-4" />
-                    <a href={`mailto:${experience.host.email}`} className="hover:underline">
-                      {experience.host.email}
-                    </a>
-                  </span>
+                                        <Mail className="h-4 w-4" />
+                                        <a href={`mailto:${experience.host.email}`} className="hover:underline">
+                                            {experience.host.email}
+                                        </a>
+                                    </span>
                                 </>
                             )}
                         </p>
                     </div>
 
-                    {/* 같이 가볼만한 곳 */}
-                    <div className="border-t border-gray-200 pt-6 mb-8">
-                        <h3 className="text-xl font-semibold mb-3 flex items-center gap-2">
-                            <Compass className="h-6 w-6 text-primary" />
-                            같이 가볼만한 곳
-                        </h3>
-                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                            {experience.nearbyPlaces.map((place, idx) => {
-                                const Icon = categoryIcons[place.category];
-                                return (
-                                    <div key={idx} className="flex flex-col rounded border bg-white shadow-sm">
-                                        <div className="relative">
-                                            <img
-                                                src={place.image || "/placeholder.svg"}
-                                                width={250}
-                                                height={150}
-                                                alt={place.name}
-                                                className="w-full aspect-[3/2] object-cover rounded-t"
-                                            />
-                                            {Icon && (
-                                                <div className="absolute top-2 left-2 bg-primary text-primary-foreground p-1 rounded-full shadow">
-                                                    <Icon className="h-5 w-5" />
-                                                </div>
-                                            )}
+                    {/* 같이 가볼만한 곳 (API에 데이터가 없으므로 렌더링되지 않음) */}
+                    {experience.nearbyPlaces && experience.nearbyPlaces.length > 0 && (
+                        <div className="border-t border-gray-200 pt-6 mb-8">
+                            <h3 className="text-xl font-semibold mb-3 flex items-center gap-2">
+                                <Compass className="h-6 w-6 text-primary" />
+                                같이 가볼만한 곳
+                            </h3>
+                            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                                {experience.nearbyPlaces.map((place: NearbyPlace, idx: number) => {
+                                    const Icon = categoryIcons[place.category];
+                                    return (
+                                        <div key={idx} className="flex flex-col rounded border bg-white shadow-sm">
                                         </div>
-                                        <div className="p-3">
-                                            <div className="text-base font-semibold">{place.name}</div>
-                                            <div className="text-xs text-gray-600 line-clamp-2">{place.description}</div>
-                                            <a href={place.link} className="text-sm text-primary hover:underline mt-2 inline-block">
-                                                자세히 보기
-                                            </a>
-                                        </div>
-                                    </div>
-                                );
-                            })}
+                                    );
+                                })}
+                            </div>
                         </div>
-                    </div>
+                    )}
+
 
                     <div className="pt-4 border-t border-gray-200">
                         <button className="w-full bg-primary text-primary-foreground hover:bg-primary/90 text-lg py-3 rounded">

--- a/front-end/src/pages/home/HomePage.tsx
+++ b/front-end/src/pages/home/HomePage.tsx
@@ -1,13 +1,37 @@
 // src/pages/home/HomePage.tsx  (또는 .jsx)
-import React from "react";
+import React, {useEffect, useState} from "react";
 import { Link } from "react-router-dom";
 import { Search, MapPin, Leaf, Users, SlidersHorizontal, Sparkles } from "lucide-react";
 
+const API_BASE = "http://localhost:8080/api/v1/experience"
+
+interface ExpListDto {
+    id : number;
+    imageUrl: string;
+    title: string;
+    description: string;
+    location: string;
+    price: number;
+    hashTag: string[];
+}
+
+
 export default function HomePage() {
+
+    const [experiences, setExperiences] = useState<ExpListDto[]>([]);
+
+    useEffect(() => {
+        fetch(`${API_BASE}/popular`)  // 백엔드 API 호출
+            .then(res => res.json())
+            .then(data => setExperiences(data))
+            .catch(err => console.error("체험 불러오기 실패:", err));
+    }, []);
+
     return (
         <>
             {/* Hero */}
-            <section className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
+            <section
+                className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
                 <div className="space-y-4 max-w-3xl">
                     <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl">
                         자연에서 찾는 나만의 저속노화 라이프
@@ -30,7 +54,7 @@ export default function HomePage() {
                                     className="inline-flex items-center gap-2 px-3 py-2 rounded bg-primary-foreground text-primary border"
                                     type="button"
                                 >
-                                    <SlidersHorizontal className="h-5 w-5" />
+                                    <SlidersHorizontal className="h-5 w-5"/>
                                     <span className="sr-only">필터</span>
                                 </button>
                             </summary>
@@ -63,14 +87,16 @@ export default function HomePage() {
 
                                     <div className="flex justify-end gap-2">
                                         <button className="px-3 py-2 border rounded">초기화</button>
-                                        <button className="px-3 py-2 rounded bg-primary text-primary-foreground">적용</button>
+                                        <button className="px-3 py-2 rounded bg-primary text-primary-foreground">적용
+                                        </button>
                                     </div>
                                 </div>
                             </div>
                         </details>
 
-                        <button type="button" className="px-3 py-2 rounded bg-secondary text-secondary-foreground border">
-                            <Search className="h-5 w-5" />
+                        <button type="button"
+                                className="px-3 py-2 rounded bg-secondary text-secondary-foreground border">
+                            <Search className="h-5 w-5"/>
                             <span className="sr-only">검색</span>
                         </button>
                     </div>
@@ -88,55 +114,41 @@ export default function HomePage() {
                     </div>
 
                     <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                        {[
-                            {
-                                title: "땅속 보물 찾기, 아이와 함께하는 감자 명상 🍠",
-                                loc: "강원도 평창",
-                                price: "50,000원",
-                                href: "/experiences/potato-farm",
-                                desc:
-                                    "흙 내음 가득한 밭에서 직접 감자를 캐며 자연과 교감하는 시간.\n아이들에게는 신나는 모험을, 어른들에게는 평화로운 휴식을 선사합니다.",
-                                tags: "#감자캐기 #가족여행 #농촌체험 #힐링",
-                            },
-                            {
-                                title: "바다의 보물, 갯벌에서 찾다",
-                                loc: "충청남도 태안",
-                                price: "35,000원",
-                                href: "/experiences/clam-digging",
-                                desc:
-                                    "드넓은 갯벌에서 신선한 조개를 직접 캐는 이색 체험.\n자연의 신비와 수확의 기쁨을 동시에 느껴보세요.",
-                                tags: "#갯벌체험 #조개잡이 #바다여행 #자연학습",
-                            },
-                            {
-                                title: "한지에 담는 한국의 미",
-                                loc: "전라북도 전주",
-                                price: "40,000원",
-                                href: "/experiences/hanji-craft",
-                                desc:
-                                    "전통 한지의 아름다움을 배우고 나만의 작품을 만드는 시간.\n고즈넉한 한옥에서 예술적 감각을 깨워보세요.",
-                                tags: "#한지공예 #전통문화 #공예체험 #전주여행",
-                            },
-                        ].map((c, i) => (
-                            <div key={i} className="flex flex-col rounded border bg-white shadow-sm">
+                        {experiences.map((c, i) => (
+                            <div key={i} className="flex flex-col rounded border bg-white shadow-sm h-full">
                                 <img
-                                    src="/placeholder.svg?height=200&width=300"
-                                    width={300}
-                                    height={200}
+                                    src={c.imageUrl}
                                     alt={`${c.title} 이미지`}
                                     className="aspect-video object-cover rounded-t"
                                 />
-                                <div className="p-4">
-                                    <h3 className="font-semibold text-lg">{c.title}</h3>
-                                    <p className="text-sm text-muted-foreground whitespace-pre-line mt-1">{c.desc}</p>
+                                <div className="p-4 flex flex-col flex-1">
+                                    {/* 제목 */}
+                                    <h3 className="font-semibold text-lg truncate">{c.title}</h3>
+
+                                    {/* 설명 */}
+                                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                                        {c.description}
+                                    </p>
+
+                                    {/* 위치 + 가격 */}
                                     <div className="flex items-center justify-between text-sm text-muted-foreground my-3">
-                    <span className="inline-flex items-center gap-1">
-                      <MapPin className="h-4 w-4" />
-                        {c.loc}
-                    </span>
-                                        <span>{c.price}</span>
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-4 w-4" />
+                  {c.location}
+              </span>
+                                        <span>{c.price.toLocaleString()}원</span>
                                     </div>
-                                    <div className="text-xs text-muted-foreground mb-3">{c.tags}</div>
-                                    <Link className="block w-full text-center px-3 py-2 rounded bg-primary text-primary-foreground" to={c.href}>
+
+                                    {/* 해시태그 */}
+                                    <div className="text-xs text-muted-foreground mb-3">
+                                        {c.hashTag.join(" ")}
+                                    </div>
+
+                                    {/* 버튼 (항상 하단 고정) */}
+                                    <Link
+                                        className="block w-full text-center px-3 py-2 rounded bg-primary text-primary-foreground mt-auto"
+                                        to={`/experiences/${c.id}`} // id 있으면 교체
+                                    >
                                         자세히 보기
                                     </Link>
                                 </div>
@@ -155,21 +167,21 @@ export default function HomePage() {
                     </p>
                     <div className="grid gap-8 md:grid-cols-3">
                         <div className="p-6 flex flex-col items-center text-center rounded border bg-white">
-                            <Sparkles className="h-12 w-12 text-primary mb-4" />
+                            <Sparkles className="h-12 w-12 text-primary mb-4"/>
                             <h3 className="font-semibold mb-2">AI 홍보글 자동 생성</h3>
                             <p className="text-sm text-muted-foreground">
                                 최소한의 정보만 입력하면 AI가 매력적인 체험 소개글을 자동으로 작성해드립니다.
                             </p>
                         </div>
                         <div className="p-6 flex flex-col items-center text-center rounded border bg-white">
-                            <Leaf className="h-12 w-12 text-primary mb-4" />
+                            <Leaf className="h-12 w-12 text-primary mb-4"/>
                             <h3 className="font-semibold mb-2">해시태그 기반 큐레이션</h3>
                             <p className="text-sm text-muted-foreground">
                                 다양한 해시태그와 검색 기능을 통해 원하는 체험을 쉽고 빠르게 찾아보세요.
                             </p>
                         </div>
                         <div className="p-6 flex flex-col items-center text-center rounded border bg-white">
-                            <Users className="h-12 w-12 text-primary mb-4" />
+                            <Users className="h-12 w-12 text-primary mb-4"/>
                             <h3 className="font-semibold mb-2">도농 상생 O2O</h3>
                             <p className="text-sm text-muted-foreground">
                                 온라인에서 쉽게 정보를 얻고 예약하여 오프라인 체험으로 이어지는 상생 구조를 만듭니다.
@@ -180,7 +192,8 @@ export default function HomePage() {
             </section>
 
             {/* CTA */}
-            <section className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
+            <section
+                className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
                 <div className="space-y-4">
                     <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl">
                         농어촌민이신가요? 당신의 삶을 공유하고 수익을 창출하세요!


### PR DESCRIPTION
- 이달의 체험 추천을 보여주도록 되어있지만 달 기준을 어찌할지 못정해서 현재는 조회수 기준으로 3개 반환
- Experience의 조회수 칼럼(viewCount) 추가
- PR시 테이블 새로 생성 필요함
- ExpDetailDto ( 데이터 상세보기 )
- 체험 목록에서 보게될 정보 반환용은 ExpListDto