### PR TITLE
<Experience> Elasticsearch 검색 기능 구현

### DIFF
--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -33,7 +33,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch:3.3.11'
+	implementation 'co.elastic.clients:elasticsearch-java:8.10.4'
 
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }

--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 

--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch:3.3.11'
-	implementation 'co.elastic.clients:elasticsearch-java:8.10.4'
 
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }

--- a/back-end/docker-compose.yml
+++ b/back-end/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.6.0
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_network
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.6.0
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - es_network
+
+networks:
+  es_network:
+    driver: bridge
+
+volumes:
+  esdata:
+    driver: local

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/config/ElasticsearchConfig.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/config/ElasticsearchConfig.java
@@ -1,0 +1,22 @@
+package com.onnongwa.back_end.domain.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+	@Value("${elasticsearch.host}")
+	private String host;
+
+	@Override
+	public ClientConfiguration clientConfiguration() {
+		return ClientConfiguration.builder()
+			.connectedTo(host)
+			.build();
+	}
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/ExperienceController.java
@@ -3,6 +3,7 @@ package com.onnongwa.back_end.domain.experience.controller;
 import java.io.IOException;
 import java.util.Map;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +17,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpOnboardingDto;
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
+import com.onnongwa.back_end.domain.experience.elasticsearch.document.ExperienceDocument;
+import com.onnongwa.back_end.domain.experience.service.ExperienceSearchService;
 import com.onnongwa.back_end.domain.experience.service.ExperienceService;
 import com.onnongwa.back_end.open_api.service.OpenApiService;
 
@@ -27,8 +30,19 @@ import lombok.RequiredArgsConstructor;
 public class ExperienceController {
 
 	private final ExperienceService experienceService;
+	private final ExperienceSearchService experienceSearchService;
 	private final OpenApiService openApiService;
 
+
+	@GetMapping("/search")
+	public ResponseEntity<Page<ExperienceDocument>> experienceSearch(
+		@RequestParam(required = false) String title,
+		@RequestParam(required = false) String keyword,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size){
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(experienceSearchService.findAutoCompleteSuggestionByKeyword(title,keyword,page,size));
+	}
 
 	@PostMapping
 	public ResponseEntity<?> registerExperience(@RequestBody ExpRegisterDto dto){
@@ -64,6 +78,4 @@ public class ExperienceController {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(Map.of("url", url));
 	}
-
-
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpListDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpListDto.java
@@ -13,6 +13,6 @@ public record ExpListDto(
 	@JsonProperty("description") String description,
 	@JsonProperty("location") String location,
 	@JsonProperty("price") int price,
-	@JsonProperty("hasTag") List<String> hashTag
+	@JsonProperty("hashTag") List<String> hashTag
 ) {
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpListDto.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/controller/dto/ExpListDto.java
@@ -2,13 +2,17 @@ package com.onnongwa.back_end.domain.experience.controller.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ExpListDto(
-	Long id,
-	String imageUrl,
-	String title,
-	String description,
-	String location,
-	int price,
-	List<String> hashTag
+	@JsonProperty("id") Long id,
+	@JsonProperty("imageUrl") String imageUrl,
+	@JsonProperty("title") String title,
+	@JsonProperty("description") String description,
+	@JsonProperty("location") String location,
+	@JsonProperty("price") int price,
+	@JsonProperty("hasTag") List<String> hashTag
 ) {
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/ExperienceDocument.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/ExperienceDocument.java
@@ -1,0 +1,65 @@
+package com.onnongwa.back_end.domain.experience.elasticsearch;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+import com.onnongwa.back_end.domain.experience.entity.Experience;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setting(settingPath = "elasticsearch/experience-setting.json")
+@Mapping(mappingPath = "elasticsearch/experience-mapping.json")
+@Document(indexName = "Experience", createIndex = true)
+@Builder
+public class ExperienceDocument {
+
+	@Id
+	@Field(type = FieldType.Long)
+	private Long id;
+
+	@Field(type = FieldType.Text)
+	private String title;           // 제목
+
+	@Field(type = FieldType.Text)
+	private String description;     // 설명
+
+	@Field(type = FieldType.Text)
+	private String location;        // 지역 (ex: 강원도 평창군)
+
+	@Field(type = FieldType.Text)
+	private String placeType;       // 실내/실외
+
+	@Field(type = FieldType.Text)
+	private String regionType;      // 농촌/어촌
+
+	@Builder
+	public ExperienceDocument(Long id, String title, String description, String location, String placeType, String regionType ){
+		this.id = id;
+		this.title = title;
+		this.description = description;
+		this.location = location;
+		this.placeType = placeType;
+		this.regionType = regionType;
+	}
+
+
+	public ExperienceDocument from(Experience experience){
+		return new ExperienceDocument(
+			experience.getId(),
+			experience.getTitle(),
+			experience.getDescription(),
+			experience.getLocation(),
+			experience.getPlaceType(),
+			experience.getRegionType()
+		);
+	}
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/document/ExperienceDocument.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/document/ExperienceDocument.java
@@ -1,4 +1,4 @@
-package com.onnongwa.back_end.domain.experience.elasticsearch;
+package com.onnongwa.back_end.domain.experience.elasticsearch.document;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -35,10 +35,10 @@ public class ExperienceDocument {
 	@Field(type = FieldType.Text)
 	private String location;        // 지역 (ex: 강원도 평창군)
 
-	@Field(type = FieldType.Text)
+	@Field(type = FieldType.Keyword)
 	private String placeType;       // 실내/실외
 
-	@Field(type = FieldType.Text)
+	@Field(type = FieldType.Keyword)
 	private String regionType;      // 농촌/어촌
 
 	@Builder

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/document/ExperienceDocument.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/document/ExperienceDocument.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Setting(settingPath = "elasticsearch/experience-setting.json")
 @Mapping(mappingPath = "elasticsearch/experience-mapping.json")
-@Document(indexName = "Experience", createIndex = true)
+@Document(indexName = "experience", createIndex = true)
 @Builder
 public class ExperienceDocument {
 
@@ -52,7 +52,7 @@ public class ExperienceDocument {
 	}
 
 
-	public ExperienceDocument from(Experience experience){
+	public static ExperienceDocument from(Experience experience){
 		return new ExperienceDocument(
 			experience.getId(),
 			experience.getTitle(),

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/document/ExperienceDocument.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/document/ExperienceDocument.java
@@ -1,5 +1,7 @@
 package com.onnongwa.back_end.domain.experience.elasticsearch.document;
 
+import java.util.List;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
@@ -7,6 +9,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.onnongwa.back_end.domain.experience.entity.Experience;
 
 import lombok.AccessLevel;
@@ -19,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Setting(settingPath = "elasticsearch/experience-setting.json")
 @Mapping(mappingPath = "elasticsearch/experience-mapping.json")
 @Document(indexName = "experience", createIndex = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
 public class ExperienceDocument {
 
@@ -36,19 +40,23 @@ public class ExperienceDocument {
 	private String location;        // 지역 (ex: 강원도 평창군)
 
 	@Field(type = FieldType.Keyword)
-	private String placeType;       // 실내/실외
+	private int price;
 
-	@Field(type = FieldType.Keyword)
-	private String regionType;      // 농촌/어촌
+	@Field(type = FieldType.Text)
+	private List<String> hashTag;
+
+	@Field(type = FieldType.Text)
+	private String imageUrl;
 
 	@Builder
-	public ExperienceDocument(Long id, String title, String description, String location, String placeType, String regionType ){
+	public ExperienceDocument(Long id, String title, String description, String location, int price, List<String> hashTag, String imageUrl ){
 		this.id = id;
 		this.title = title;
 		this.description = description;
 		this.location = location;
-		this.placeType = placeType;
-		this.regionType = regionType;
+		this.price = price;
+		this.hashTag = hashTag;
+		this.imageUrl = imageUrl;
 	}
 
 
@@ -58,8 +66,9 @@ public class ExperienceDocument {
 			experience.getTitle(),
 			experience.getDescription(),
 			experience.getLocation(),
-			experience.getPlaceType(),
-			experience.getRegionType()
+			experience.getPrice(),
+			experience.getHashtags(),
+			experience.getImageUrl()
 		);
 	}
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/repository/ExperienceElasticRepository.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/repository/ExperienceElasticRepository.java
@@ -1,8 +1,11 @@
 package com.onnongwa.back_end.domain.experience.elasticsearch.repository;
 
+import java.util.List;
+
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 import com.onnongwa.back_end.domain.experience.elasticsearch.document.ExperienceDocument;
 
 public interface ExperienceElasticRepository extends ElasticsearchRepository<ExperienceDocument, Long> {
+	List<ExperienceDocument> findByTitle(String keyword);
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/repository/ExperienceElasticRepository.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/repository/ExperienceElasticRepository.java
@@ -1,0 +1,8 @@
+package com.onnongwa.back_end.domain.experience.elasticsearch.repository;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import com.onnongwa.back_end.domain.experience.elasticsearch.document.ExperienceDocument;
+
+public interface ExperienceElasticRepository extends ElasticsearchRepository<ExperienceDocument, Long> {
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/repository/ExperienceElasticRepository.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/elasticsearch/repository/ExperienceElasticRepository.java
@@ -7,5 +7,4 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import com.onnongwa.back_end.domain.experience.elasticsearch.document.ExperienceDocument;
 
 public interface ExperienceElasticRepository extends ElasticsearchRepository<ExperienceDocument, Long> {
-	List<ExperienceDocument> findByTitle(String keyword);
 }

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/entity/Experience.java
@@ -23,6 +23,7 @@ public class Experience {
 
     // 기본 정보
     private String title;           // 제목
+    @Column(length = 1000)
     private String description;     // 설명
     private String location;        // 지역 (ex: 강원도 평창군)
     private String duration;        // 총 소요 시간 (ex: "약 5시간")

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceSearchService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceSearchService.java
@@ -1,0 +1,84 @@
+package com.onnongwa.back_end.domain.experience.service;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.onnongwa.back_end.domain.experience.elasticsearch.document.ExperienceDocument;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ExperienceSearchService {
+
+	private final ElasticsearchClient elasticsearchClient;
+
+	public Page<ExperienceDocument> findAutoCompleteSuggestionByKeyword(String title, String keyword, int page, int size){
+		Pageable pageable = PageRequest.of(page,size);
+		try{
+			Query query = buildSeaarchQuery(title,keyword);
+
+			SearchRequest searchRequest = new SearchRequest.Builder()
+				.index("experience")
+				.query(query)
+				.from(page * size)
+				.size(size)
+				.build();
+
+			SearchResponse<ExperienceDocument> searchRes = elasticsearchClient.search(searchRequest,
+				ExperienceDocument.class);
+
+			List<ExperienceDocument> expList = searchRes.hits().hits().stream()
+				.map(Hit ::source)
+				.toList();
+
+			return new PageImpl<>(expList, pageable, searchRes.hits().total().value());
+		} catch (IOException e) {
+			return Page.empty();
+		}
+	}
+
+	private Query buildSeaarchQuery(String title, String keyword) {
+		BoolQuery.Builder builder = new BoolQuery.Builder();
+
+		if (title != null){
+			builder.should(s ->s
+				.match(m -> m
+					.field("title")
+					.query(title)
+				)
+			);
+		};
+
+		if (keyword != null){
+			builder.should(s -> s
+				.multiMatch(m -> m
+					.fields("description", "location","crops")
+					.query(keyword)
+				)
+			);
+		}
+
+		if (!StringUtils.hasText(title) && !StringUtils.hasText(keyword)) {
+			return new Query.Builder().matchAll(m -> m).build();
+		}
+
+		return new Query.Builder()
+			.bool(builder.minimumShouldMatch("1").build())
+			.build();
+	}
+
+}

--- a/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
+++ b/back-end/src/main/java/com/onnongwa/back_end/domain/experience/service/ExperienceService.java
@@ -16,6 +16,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpDetailDto;
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpListDto;
 import com.onnongwa.back_end.domain.experience.controller.dto.ExpRegisterDto;
+import com.onnongwa.back_end.domain.experience.elasticsearch.document.ExperienceDocument;
+import com.onnongwa.back_end.domain.experience.elasticsearch.repository.ExperienceElasticRepository;
 import com.onnongwa.back_end.domain.experience.entity.Experience;
 import com.onnongwa.back_end.domain.experience.entity.ExperienceSchedule;
 import com.onnongwa.back_end.domain.experience.repository.ExperienceRepository;
@@ -31,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 public class ExperienceService {
 
 	private final ExperienceRepository experienceRepository;
+	private final ExperienceElasticRepository experienceElasticRepository;
 	private final FarmRepository farmRepository;
 
 	private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
@@ -41,7 +44,9 @@ public class ExperienceService {
 
 		Farm farm = farmRepository.findById(1L).orElseThrow(() -> new EntityNotFoundException("Farm not found with id : 1L"));
 
-		experienceRepository.save(Experience.from(dto,farm));
+		Experience experience = experienceRepository.save(Experience.from(dto,farm));;
+
+		experienceElasticRepository.save(ExperienceDocument.from(experience));
 	}
 
 	@Transactional
@@ -86,6 +91,4 @@ public class ExperienceService {
 
 		return IMAGE_BASE_URL + savedFileName;
 	}
-
-
 }

--- a/back-end/src/main/resources/application.yaml
+++ b/back-end/src/main/resources/application.yaml
@@ -36,3 +36,6 @@ openai:
     key: ${OPENAI_API_KEY}
     url: https://api.openai.com/v1/chat/completions
     model : gpt-4
+
+elasticsearch:
+  host: ${ELASTICSEARCH_HOST}

--- a/back-end/src/main/resources/elasticsearch/experience-mapping.json
+++ b/back-end/src/main/resources/elasticsearch/experience-mapping.json
@@ -1,0 +1,28 @@
+{
+  "properties": {
+    "id": {
+      "type": "long"
+    },
+    "title": {
+      "type": "text",
+      "analyzer": "korean_analyzer",
+      "search_analyzer": "korean_analyzer"
+    },
+    "description": {
+      "type": "text",
+      "analyzer": "korean_analyzer",
+      "search_analyzer": "korean_analyzer"
+    },
+    "location": {
+      "type": "text",
+      "analyzer": "korean_analyzer",
+      "search_analyzer": "korean_analyzer"
+    },
+    "placeType": {
+      "type": "keyword"
+    },
+    "regionType": {
+      "type": "keyword"
+    }
+  }
+}

--- a/back-end/src/main/resources/elasticsearch/experience-mapping.json
+++ b/back-end/src/main/resources/elasticsearch/experience-mapping.json
@@ -5,18 +5,18 @@
     },
     "title": {
       "type": "text",
-      "analyzer": "korean_analyzer",
-      "search_analyzer": "korean_analyzer"
+      "analyzer": "korean_index_analyzer",
+      "search_analyzer": "korean_search_analyzer"
     },
     "description": {
       "type": "text",
-      "analyzer": "korean_analyzer",
-      "search_analyzer": "korean_analyzer"
+      "analyzer": "korean_index_analyzer",
+      "search_analyzer": "korean_search_analyzer"
     },
     "location": {
       "type": "text",
-      "analyzer": "korean_analyzer",
-      "search_analyzer": "korean_analyzer"
+      "analyzer": "korean_index_analyzer",
+      "search_analyzer": "korean_search_analyzer"
     },
     "placeType": {
       "type": "keyword"

--- a/back-end/src/main/resources/elasticsearch/experience-setting.json
+++ b/back-end/src/main/resources/elasticsearch/experience-setting.json
@@ -1,7 +1,22 @@
 {
   "analysis": {
+    "tokenizer": {
+      "edge_ngram_tokenizer": {
+        "type": "edge_ngram",
+        "min_gram": 2,
+        "max_gram": 20,
+        "token_chars": ["letter", "digit", "hangul"]
+      }
+    },
     "analyzer": {
-      "korean_analyzer": {
+      "korean_index_analyzer": {
+        "type": "custom",
+        "tokenizer": "edge_ngram_tokenizer",
+        "filter": [
+          "lowercase"
+        ]
+      },
+      "korean_search_analyzer": {
         "type": "custom",
         "tokenizer": "nori_tokenizer",
         "filter": [

--- a/back-end/src/main/resources/elasticsearch/experience-setting.json
+++ b/back-end/src/main/resources/elasticsearch/experience-setting.json
@@ -1,0 +1,14 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": [
+          "nori_part_of_speech",
+          "lowercase"
+        ]
+      }
+    }
+  }
+}

--- a/front-end/src/pages/experience/ExperiencesPage.tsx
+++ b/front-end/src/pages/experience/ExperiencesPage.tsx
@@ -1,165 +1,105 @@
-// src/pages/experience/ExperiencesPage.tsx
-import React, { useMemo, useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { MapPin, Clock, Search, Filter } from "lucide-react";
+import { MapPin, Clock, Search, Filter, Loader2 } from "lucide-react";
 
+// 프론트엔드에서 사용할 데이터 타입
 type Experience = {
     id: string;
     title: string;
     description: string;
     location: string;
-    region: string;       // 지역 (강원도, 경기도 등)
     price: string;
-    duration: string;
-    category: string;     // 농촌체험, 어촌체험, 공예체험, 힐링체험 등
     tags: string[];
+    imageUrl: string;
+    // --- API에 없는 데이터 ---
+    duration: string; // 임시 데이터로 처리
+};
+
+// API 응답 객체 내부의 content 타입
+type ApiExperience = {
+    id: number;
+    title: string;
+    description: string;
+    location: string;
+    price: number;
+    hashTag: string[];
     imageUrl: string;
 };
 
-const ALL_EXPERIENCES: Experience[] = [
-    {
-        id: "potato-farm",
-        title: "땅속 보물 찾기, 아이와 함께하는 감자 명상 🍠",
-        description:
-            "흙 내음 가득한 밭에서 직접 감자를 캐며 자연과 교감하는 시간. 아이들에게는 신나는 모험을, 어른들에게는 평화로운 휴식을 선사합니다.",
-        location: "강원도 평창",
-        region: "강원도",
-        price: "50,000원",
-        duration: "약 3시간",
-        category: "농촌체험",
-        tags: ["#감자캐기", "#가족여행", "#농촌체험", "#힐링"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-    {
-        id: "clam-digging",
-        title: "바다의 보물, 갯벌에서 찾다",
-        description:
-            "드넓은 갯벌에서 신선한 조개를 직접 캐는 이색 체험. 자연의 신비와 수확의 기쁨을 동시에 느껴보세요.",
-        location: "충청남도 태안",
-        region: "충청남도",
-        price: "35,000원",
-        duration: "약 2시간",
-        category: "어촌체험",
-        tags: ["#갯벌체험", "#조개잡이", "#바다여행", "#자연학습"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-    {
-        id: "hanji-craft",
-        title: "한지에 담는 한국의 미",
-        description:
-            "전통 한지의 아름다움을 배우고 나만의 작품을 만드는 시간. 고즈넉한 한옥에서 예술적 감각을 깨워보세요.",
-        location: "전라북도 전주",
-        region: "전라북도",
-        price: "40,000원",
-        duration: "약 2.5시간",
-        category: "공예체험",
-        tags: ["#한지공예", "#전통문화", "#공예체험", "#전주여행"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-    {
-        id: "forest-healing",
-        title: "숲속 힐링 명상 & 차담 체험 🧘‍♀️🍵",
-        description:
-            "바쁜 일상에 지친 당신을 위한 완벽한 휴식! 고요한 숲속에서 자연의 소리를 들으며 깊은 명상에 잠기고, 향긋한 전통차와 함께 마음을 나누는 시간.",
-        location: "경기도 가평",
-        region: "경기도",
-        price: "45,000원",
-        duration: "약 2시간",
-        category: "힐링체험",
-        tags: ["#숲속명상", "#차담", "#힐링체험", "#자연치유"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-    {
-        id: "strawberry-picking",
-        title: "달콤한 봄날, 딸기 따기 체험 🍓",
-        description:
-            "빨갛게 익은 달콤한 딸기를 직접 따며 봄의 향기를 만끽하세요. 갓 딴 딸기로 만든 잼 만들기 체험도 함께!",
-        location: "경기도 양평",
-        region: "경기도",
-        price: "30,000원",
-        duration: "약 2.5시간",
-        category: "농촌체험",
-        tags: ["#딸기따기", "#봄체험", "#잼만들기", "#가족체험"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-    {
-        id: "pottery-making",
-        title: "흙과 함께하는 도자기 만들기",
-        description:
-            "전통 도예 기법을 배우며 나만의 도자기를 만들어보세요. 완성된 작품은 구워서 택배로 보내드립니다.",
-        location: "경상북도 경주",
-        region: "경상북도",
-        price: "55,000원",
-        duration: "약 3시간",
-        category: "공예체험",
-        tags: ["#도자기", "#전통공예", "#핸드메이드", "#경주여행"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-    {
-        id: "rice-planting",
-        title: "논에서 만나는 우리 쌀 이야기",
-        description:
-            "직접 모내기를 체험하고 우리 쌀의 소중함을 배워보세요. 전통 농기구 체험과 농촌 점심 식사도 포함!",
-        location: "전라남도 나주",
-        region: "전라남도",
-        price: "25,000원",
-        duration: "약 4시간",
-        category: "농촌체험",
-        tags: ["#모내기", "#쌀체험", "#농촌생활", "#전통농업"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-    {
-        id: "seaweed-harvesting",
-        title: "바다 농부가 되어보자! 미역 채취 체험",
-        description:
-            "새벽 바다에서 미역을 직접 채취하고 가공하는 과정을 체험해보세요. 신선한 해산물 시식도 함께!",
-        location: "제주도 서귀포",
-        region: "제주도",
-        price: "60,000원",
-        duration: "약 3.5시간",
-        category: "어촌체험",
-        tags: ["#미역채취", "#제주바다", "#해녀체험", "#해산물"],
-        imageUrl: "/placeholder.svg?height=200&width=300",
-    },
-];
+// API 페이징 응답 전체 타입
+type ApiResponse = {
+    content: ApiExperience[];
+    totalPages: number;
+    totalElements: number;
+    number: number; // 현재 페이지 (0부터 시작)
+};
+
+const API_BASE_URL = "http://localhost:8080/api/v1/experience/search";
 
 export default function ExperiencesPage() {
+    // 1. 상태 관리 변경
+    const [experiences, setExperiences] = useState<Experience[]>([]);
     const [search, setSearch] = useState("");
-    const [region, setRegion] = useState("전체 지역");
-    const [category, setCategory] = useState("전체 카테고리");
-    const [page, setPage] = useState(1);
-    const perPage = 5;
+    const [page, setPage] = useState(1); // 페이지는 1부터 시작
+    const [totalPages, setTotalPages] = useState(1);
+    const [totalElements, setTotalElements] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
-    const regions = useMemo(
-        () => Array.from(new Set(ALL_EXPERIENCES.map((e) => e.region))),
-        []
-    );
-    const categories = useMemo(
-        () => Array.from(new Set(ALL_EXPERIENCES.map((e) => e.category))),
-        []
-    );
+    const perPage = 5; // 한 페이지에 보여줄 아이템 수 (백엔드와 협의 필요)
 
-    const filtered = useMemo(() => {
-        return ALL_EXPERIENCES.filter((e) => {
-            const matchesSearch =
-                !search ||
-                e.title.toLowerCase().includes(search.toLowerCase()) ||
-                e.description.toLowerCase().includes(search.toLowerCase());
-            const matchesRegion = region === "전체 지역" || e.region === region;
-            const matchesCategory =
-                category === "전체 카테고리" || e.category === category;
-            return matchesSearch && matchesRegion && matchesCategory;
-        });
-    }, [search, region, category]);
+    // 2. API 호출 로직 (useEffect)
+    useEffect(() => {
+        const fetchExperiences = async () => {
+            setIsLoading(true);
+            setError(null);
 
-    const totalPages = Math.ceil(filtered.length / perPage) || 1;
-    const start = (page - 1) * perPage;
-    const current = filtered.slice(start, start + perPage);
+            try {
+                // URL 쿼리 파라미터 생성
+                const params = new URLSearchParams();
+                if (search) {
+                    params.append("keyword", search);
+                }
+                params.append("page", (page - 1).toString()); // API는 0-based page
+                params.append("size", perPage.toString());
+
+                const response = await fetch(`${API_BASE_URL}?${params.toString()}`);
+                if (!response.ok) {
+                    throw new Error("데이터를 불러오는 데 실패했습니다.");
+                }
+
+                const data: ApiResponse = await response.json();
+
+                // 3. 데이터 매핑 (API 응답 -> 프론트엔드 타입)
+                const mappedData: Experience[] = data.content.map((item) => ({
+                    id: item.id.toString(),
+                    title: item.title,
+                    description: item.description,
+                    location: item.location,
+                    price: `${item.price.toLocaleString()}원`,
+                    tags: item.hashTag,
+                    imageUrl: item.imageUrl,
+                    duration: "정보 없음", // API에 duration 정보가 없으므로 임시 처리
+                }));
+
+                setExperiences(mappedData);
+                setTotalPages(data.totalPages);
+                setTotalElements(data.totalElements);
+
+            } catch (err) {
+                if (err instanceof Error) {
+                    setError(err.message);
+                }
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchExperiences();
+    }, [search, page]); // 검색어 또는 페이지가 변경될 때마다 API 호출
 
     const resetFilters = () => {
         setSearch("");
-        setRegion("전체 지역");
-        setCategory("전체 카테고리");
         setPage(1);
     };
 
@@ -174,90 +114,61 @@ export default function ExperiencesPage() {
 
                 {/* 검색/필터 */}
                 <div className="space-y-4">
-                    {/* 검색창 */}
                     <div className="flex gap-2">
                         <div className="flex-1 relative">
                             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
                             <input
                                 type="search"
-                                placeholder="체험명이나 키워드로 검색하세요"
+                                placeholder="키워드로 검색하세요"
                                 className="w-full pl-10 border rounded px-3 py-2"
                                 value={search}
                                 onChange={(e) => {
                                     setSearch(e.target.value);
-                                    setPage(1);
+                                    setPage(1); // 검색 시 첫 페이지로
                                 }}
                             />
                         </div>
                     </div>
 
-                    {/* 필터 */}
-                    <div className="grid grid-cols-2 gap-4">
-                        <select
-                            className="border rounded px-3 py-2"
-                            value={region}
-                            onChange={(e) => {
-                                setRegion(e.target.value);
-                                setPage(1);
-                            }}
-                        >
-                            <option value="전체 지역">전체 지역</option>
-                            {regions.map((r) => (
-                                <option key={r} value={r}>
-                                    {r}
-                                </option>
-                            ))}
-                        </select>
-
-                        <select
-                            className="border rounded px-3 py-2"
-                            value={category}
-                            onChange={(e) => {
-                                setCategory(e.target.value);
-                                setPage(1);
-                            }}
-                        >
-                            <option value="전체 카테고리">전체 카테고리</option>
-                            {categories.map((c) => (
-                                <option key={c} value={c}>
-                                    {c}
-                                </option>
-                            ))}
-                        </select>
-                    </div>
-
-                    {(search || region !== "전체 지역" || category !== "전체 카테고리") && (
+                    {search && (
                         <button
                             type="button"
                             onClick={resetFilters}
                             className="w-full inline-flex items-center justify-center gap-2 border rounded px-3 py-2"
                         >
                             <Filter className="h-4 w-4" />
-                            필터 초기화
+                            검색 초기화
                         </button>
                     )}
                 </div>
 
                 {/* 개수 표시 */}
                 <div className="text-sm text-gray-500 text-center">
-                    총 <span className="font-semibold text-primary">{filtered.length}</span>개의 체험이 있습니다
+                    총 <span className="font-semibold text-primary">{totalElements}</span>개의 체험이 있습니다
                     {totalPages > 1 && (
                         <span className="ml-2">
-              (페이지 {page} / {totalPages})
-            </span>
+                            (페이지 {page} / {totalPages})
+                        </span>
                     )}
                 </div>
 
                 {/* 목록 */}
                 <div className="space-y-4">
-                    {current.length > 0 ? (
-                        current.map((e) => (
+                    {isLoading ? (
+                        <div className="flex justify-center items-center py-12">
+                            <Loader2 className="h-12 w-12 animate-spin text-primary" />
+                        </div>
+                    ) : error ? (
+                        <div className="text-center py-12 text-red-500">{error}</div>
+                    ) : experiences.length > 0 ? (
+                        experiences.map((e) => (
+                            // ... 기존 JSX 구조와 동일 ...
+                            // key={e.id}, Link to={`/experiences/${e.id}`} 등 그대로 사용
                             <div
                                 key={e.id}
                                 className="overflow-hidden rounded border bg-white hover:shadow-md transition-shadow duration-200"
                             >
                                 <div className="flex">
-                                    {/* 이미지 */}
                                     <div className="w-24 h-24 flex-shrink-0">
                                         <img
                                             src={e.imageUrl || "/placeholder.svg"}
@@ -265,36 +176,17 @@ export default function ExperiencesPage() {
                                             className="w-full h-full object-cover"
                                         />
                                     </div>
-
-                                    {/* 내용 */}
                                     <div className="flex-1 p-3">
                                         <div className="pb-2">
-                                            <div className="text-base font-bold line-clamp-2 leading-tight">
-                                                {e.title}
-                                            </div>
-                                            <div className="text-sm text-gray-600 line-clamp-2">
-                                                {e.description}
-                                            </div>
+                                            <div className="text-base font-bold line-clamp-2 leading-tight">{e.title}</div>
+                                            <div className="text-sm text-gray-600 line-clamp-2">{e.description}</div>
                                         </div>
-
-                                        {/* 태그 */}
                                         <div className="flex flex-wrap gap-1 mb-2">
                                             {e.tags.slice(0, 3).map((t, i) => (
-                                                <span
-                                                    key={i}
-                                                    className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full text-xs"
-                                                >
-                          {t}
-                        </span>
+                                                <span key={i} className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full text-xs">{t}</span>
                                             ))}
-                                            {e.tags.length > 3 && (
-                                                <span className="text-xs text-gray-500 px-2 py-0.5">
-                          +{e.tags.length - 3}
-                        </span>
-                                            )}
+                                            {e.tags.length > 3 && <span className="text-xs text-gray-500 px-2 py-0.5">+{e.tags.length - 3}</span>}
                                         </div>
-
-                                        {/* 메타 */}
                                         <div className="flex items-center justify-between text-sm">
                                             <div className="flex items-center gap-3">
                                                 <div className="flex items-center gap-1 text-gray-600">
@@ -308,12 +200,7 @@ export default function ExperiencesPage() {
                                             </div>
                                             <div className="text-base font-bold text-primary">{e.price}</div>
                                         </div>
-
-                                        {/* 버튼 */}
-                                        <Link
-                                            to={`/experiences/${e.id}`}
-                                            className="block w-full mt-2 text-center rounded bg-primary text-white py-2"
-                                        >
+                                        <Link to={`/experiences/${e.id}`} className="block w-full mt-2 text-center rounded bg-primary text-white py-2">
                                             자세히 보기
                                         </Link>
                                     </div>
@@ -324,20 +211,14 @@ export default function ExperiencesPage() {
                         <div className="text-center py-12">
                             <Search className="h-12 w-12 mx-auto mb-4 opacity-50 text-gray-400" />
                             <p className="text-lg font-medium">검색 결과가 없습니다</p>
-                            <p className="text-sm text-gray-500 mb-4">다른 검색어나 필터를 시도해보세요</p>
-                            <button
-                                type="button"
-                                onClick={resetFilters}
-                                className="border rounded px-4 py-2"
-                            >
-                                전체 체험 보기
-                            </button>
+                            <p className="text-sm text-gray-500 mb-4">다른 키워드를 시도해보세요</p>
                         </div>
                     )}
                 </div>
 
+
                 {/* 페이징 */}
-                {totalPages > 1 && (
+                {!isLoading && totalPages > 1 && (
                     <div className="flex justify-center items-center gap-2 mt-8">
                         <button
                             type="button"

--- a/front-end/src/pages/experience/ExperiencesPage.tsx
+++ b/front-end/src/pages/experience/ExperiencesPage.tsx
@@ -1,8 +1,8 @@
+// src/pages/experience/ExperiencesPage.tsx
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { MapPin, Clock, Search, Filter, Loader2 } from "lucide-react";
 
-// 프론트엔드에서 사용할 데이터 타입
 type Experience = {
     id: string;
     title: string;
@@ -11,11 +11,9 @@ type Experience = {
     price: string;
     tags: string[];
     imageUrl: string;
-    // --- API에 없는 데이터 ---
-    duration: string; // 임시 데이터로 처리
+    duration: string;
 };
 
-// API 응답 객체 내부의 content 타입
 type ApiExperience = {
     id: number;
     title: string;
@@ -26,41 +24,40 @@ type ApiExperience = {
     imageUrl: string;
 };
 
-// API 페이징 응답 전체 타입
 type ApiResponse = {
     content: ApiExperience[];
     totalPages: number;
     totalElements: number;
-    number: number; // 현재 페이지 (0부터 시작)
+    number: number;
 };
 
 const API_BASE_URL = "http://localhost:8080/api/v1/experience/search";
 
 export default function ExperiencesPage() {
-    // 1. 상태 관리 변경
+    const [searchParams] = useSearchParams();
+    const initialKeyword = searchParams.get("keyword") || "";
+
     const [experiences, setExperiences] = useState<Experience[]>([]);
-    const [search, setSearch] = useState("");
-    const [page, setPage] = useState(1); // 페이지는 1부터 시작
+    const [search, setSearch] = useState(initialKeyword);
+    const [page, setPage] = useState(1);
     const [totalPages, setTotalPages] = useState(1);
     const [totalElements, setTotalElements] = useState(0);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    const perPage = 5; // 한 페이지에 보여줄 아이템 수 (백엔드와 협의 필요)
+    const perPage = 5;
 
-    // 2. API 호출 로직 (useEffect)
     useEffect(() => {
         const fetchExperiences = async () => {
             setIsLoading(true);
             setError(null);
 
             try {
-                // URL 쿼리 파라미터 생성
                 const params = new URLSearchParams();
                 if (search) {
                     params.append("keyword", search);
                 }
-                params.append("page", (page - 1).toString()); // API는 0-based page
+                params.append("page", (page - 1).toString());
                 params.append("size", perPage.toString());
 
                 const response = await fetch(`${API_BASE_URL}?${params.toString()}`);
@@ -70,7 +67,6 @@ export default function ExperiencesPage() {
 
                 const data: ApiResponse = await response.json();
 
-                // 3. 데이터 매핑 (API 응답 -> 프론트엔드 타입)
                 const mappedData: Experience[] = data.content.map((item) => ({
                     id: item.id.toString(),
                     title: item.title,
@@ -79,13 +75,12 @@ export default function ExperiencesPage() {
                     price: `${item.price.toLocaleString()}원`,
                     tags: item.hashTag,
                     imageUrl: item.imageUrl,
-                    duration: "정보 없음", // API에 duration 정보가 없으므로 임시 처리
+                    duration: "정보 없음",
                 }));
 
                 setExperiences(mappedData);
                 setTotalPages(data.totalPages);
                 setTotalElements(data.totalElements);
-
             } catch (err) {
                 if (err instanceof Error) {
                     setError(err.message);
@@ -96,7 +91,7 @@ export default function ExperiencesPage() {
         };
 
         fetchExperiences();
-    }, [search, page]); // 검색어 또는 페이지가 변경될 때마다 API 호출
+    }, [search, page]);
 
     const resetFilters = () => {
         setSearch("");
@@ -108,11 +103,15 @@ export default function ExperiencesPage() {
             <div className="space-y-6 max-w-2xl mx-auto">
                 {/* 제목 */}
                 <div className="text-center space-y-2">
-                    <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl">체험 정보</h1>
-                    <p className="text-muted-foreground">다양한 농어촌 체험을 찾아보고 예약하세요</p>
+                    <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl">
+                        체험 정보
+                    </h1>
+                    <p className="text-muted-foreground">
+                        다양한 농어촌 체험을 찾아보고 예약하세요
+                    </p>
                 </div>
 
-                {/* 검색/필터 */}
+                {/* 검색 */}
                 <div className="space-y-4">
                     <div className="flex gap-2">
                         <div className="flex-1 relative">
@@ -124,7 +123,7 @@ export default function ExperiencesPage() {
                                 value={search}
                                 onChange={(e) => {
                                     setSearch(e.target.value);
-                                    setPage(1); // 검색 시 첫 페이지로
+                                    setPage(1);
                                 }}
                             />
                         </div>
@@ -142,13 +141,15 @@ export default function ExperiencesPage() {
                     )}
                 </div>
 
-                {/* 개수 표시 */}
+                {/* 개수 */}
                 <div className="text-sm text-gray-500 text-center">
-                    총 <span className="font-semibold text-primary">{totalElements}</span>개의 체험이 있습니다
+                    총{" "}
+                    <span className="font-semibold text-primary">{totalElements}</span>개의
+                    체험이 있습니다
                     {totalPages > 1 && (
                         <span className="ml-2">
-                            (페이지 {page} / {totalPages})
-                        </span>
+              (페이지 {page} / {totalPages})
+            </span>
                     )}
                 </div>
 
@@ -162,8 +163,6 @@ export default function ExperiencesPage() {
                         <div className="text-center py-12 text-red-500">{error}</div>
                     ) : experiences.length > 0 ? (
                         experiences.map((e) => (
-                            // ... 기존 JSX 구조와 동일 ...
-                            // key={e.id}, Link to={`/experiences/${e.id}`} 등 그대로 사용
                             <div
                                 key={e.id}
                                 className="overflow-hidden rounded border bg-white hover:shadow-md transition-shadow duration-200"
@@ -178,14 +177,27 @@ export default function ExperiencesPage() {
                                     </div>
                                     <div className="flex-1 p-3">
                                         <div className="pb-2">
-                                            <div className="text-base font-bold line-clamp-2 leading-tight">{e.title}</div>
-                                            <div className="text-sm text-gray-600 line-clamp-2">{e.description}</div>
+                                            <div className="text-base font-bold line-clamp-2 leading-tight">
+                                                {e.title}
+                                            </div>
+                                            <div className="text-sm text-gray-600 line-clamp-2">
+                                                {e.description}
+                                            </div>
                                         </div>
                                         <div className="flex flex-wrap gap-1 mb-2">
                                             {e.tags.slice(0, 3).map((t, i) => (
-                                                <span key={i} className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full text-xs">{t}</span>
+                                                <span
+                                                    key={i}
+                                                    className="bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full text-xs"
+                                                >
+                          {t}
+                        </span>
                                             ))}
-                                            {e.tags.length > 3 && <span className="text-xs text-gray-500 px-2 py-0.5">+{e.tags.length - 3}</span>}
+                                            {e.tags.length > 3 && (
+                                                <span className="text-xs text-gray-500 px-2 py-0.5">
+                          +{e.tags.length - 3}
+                        </span>
+                                            )}
                                         </div>
                                         <div className="flex items-center justify-between text-sm">
                                             <div className="flex items-center gap-3">
@@ -198,9 +210,14 @@ export default function ExperiencesPage() {
                                                     <span>{e.duration}</span>
                                                 </div>
                                             </div>
-                                            <div className="text-base font-bold text-primary">{e.price}</div>
+                                            <div className="text-base font-bold text-primary">
+                                                {e.price}
+                                            </div>
                                         </div>
-                                        <Link to={`/experiences/${e.id}`} className="block w-full mt-2 text-center rounded bg-primary text-white py-2">
+                                        <Link
+                                            to={`/experiences/${e.id}`}
+                                            className="block w-full mt-2 text-center rounded bg-primary text-white py-2"
+                                        >
                                             자세히 보기
                                         </Link>
                                     </div>
@@ -211,11 +228,12 @@ export default function ExperiencesPage() {
                         <div className="text-center py-12">
                             <Search className="h-12 w-12 mx-auto mb-4 opacity-50 text-gray-400" />
                             <p className="text-lg font-medium">검색 결과가 없습니다</p>
-                            <p className="text-sm text-gray-500 mb-4">다른 키워드를 시도해보세요</p>
+                            <p className="text-sm text-gray-500 mb-4">
+                                다른 키워드를 시도해보세요
+                            </p>
                         </div>
                     )}
                 </div>
-
 
                 {/* 페이징 */}
                 {!isLoading && totalPages > 1 && (

--- a/front-end/src/pages/home/HomePage.tsx
+++ b/front-end/src/pages/home/HomePage.tsx
@@ -1,12 +1,12 @@
-// src/pages/home/HomePage.tsx  (또는 .jsx)
-import React, {useEffect, useState} from "react";
-import { Link } from "react-router-dom";
-import { Search, MapPin, Leaf, Users, SlidersHorizontal, Sparkles } from "lucide-react";
+// src/pages/home/HomePage.tsx
+import React, { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Search, MapPin, Leaf, Users, Sparkles } from "lucide-react";
 
-const API_BASE = "http://localhost:8080/api/v1/experience"
+const API_BASE = "http://localhost:8080/api/v1/experience";
 
 interface ExpListDto {
-    id : number;
+    id: number;
     imageUrl: string;
     title: string;
     description: string;
@@ -15,23 +15,30 @@ interface ExpListDto {
     hashTag: string[];
 }
 
-
 export default function HomePage() {
-
     const [experiences, setExperiences] = useState<ExpListDto[]>([]);
+    const [query, setQuery] = useState("");
+    const navigate = useNavigate();
 
     useEffect(() => {
-        fetch(`${API_BASE}/popular`)  // 백엔드 API 호출
-            .then(res => res.json())
-            .then(data => setExperiences(data))
-            .catch(err => console.error("체험 불러오기 실패:", err));
+        fetch(`${API_BASE}/popular`)
+            .then((res) => res.json())
+            .then((data) => setExperiences(data))
+            .catch((err) => console.error("체험 불러오기 실패:", err));
     }, []);
+
+    const handleSearch = () => {
+        if (query.trim()) {
+            navigate(`/experiences?keyword=${encodeURIComponent(query.trim())}`);
+        } else {
+            navigate("/experiences");
+        }
+    };
 
     return (
         <>
             {/* Hero */}
-            <section
-                className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
+            <section className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
                 <div className="space-y-4 max-w-3xl">
                     <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl">
                         자연에서 찾는 나만의 저속노화 라이프
@@ -45,58 +52,19 @@ export default function HomePage() {
                             type="search"
                             placeholder="어떤 체험을 찾으시나요?"
                             className="flex-1 bg-primary-foreground text-foreground px-3 py-2 rounded border border-gray-200"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") handleSearch();
+                            }}
                         />
 
-                        {/* Dialog 대체: details로 임시 처리 */}
-                        <details className="relative">
-                            <summary className="list-none">
-                                <button
-                                    className="inline-flex items-center gap-2 px-3 py-2 rounded bg-primary-foreground text-primary border"
-                                    type="button"
-                                >
-                                    <SlidersHorizontal className="h-5 w-5"/>
-                                    <span className="sr-only">필터</span>
-                                </button>
-                            </summary>
-                            <div className="absolute right-0 mt-2 w-72 rounded border bg-white p-4 shadow">
-                                <h3 className="font-semibold mb-2">체험 필터</h3>
-                                <div className="grid gap-4">
-                                    <div className="grid grid-cols-4 items-center gap-2">
-                                        <label className="text-right col-span-1">지역</label>
-                                        <select className="col-span-3 border rounded px-2 py-1">
-                                            <option>지역 선택</option>
-                                            <option value="gangwon">강원도</option>
-                                            <option value="gyeonggi">경기도</option>
-                                            <option value="chungcheong">충청도</option>
-                                            <option value="jeolla">전라도</option>
-                                            <option value="gyeongsang">경상도</option>
-                                            <option value="jeju">제주도</option>
-                                        </select>
-                                    </div>
-
-                                    <div className="grid grid-cols-4 items-center gap-2">
-                                        <label className="text-right col-span-1">체험 종류</label>
-                                        <select className="col-span-3 border rounded px-2 py-1">
-                                            <option>종류 선택</option>
-                                            <option value="farm">농촌 체험</option>
-                                            <option value="fishing">어촌 체험</option>
-                                            <option value="craft">공예 체험</option>
-                                            <option value="healing">힐링 체험</option>
-                                        </select>
-                                    </div>
-
-                                    <div className="flex justify-end gap-2">
-                                        <button className="px-3 py-2 border rounded">초기화</button>
-                                        <button className="px-3 py-2 rounded bg-primary text-primary-foreground">적용
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </details>
-
-                        <button type="button"
-                                className="px-3 py-2 rounded bg-secondary text-secondary-foreground border">
-                            <Search className="h-5 w-5"/>
+                        <button
+                            type="button"
+                            className="px-3 py-2 rounded bg-secondary text-secondary-foreground border"
+                            onClick={handleSearch}
+                        >
+                            <Search className="h-5 w-5" />
                             <span className="sr-only">검색</span>
                         </button>
                     </div>
@@ -107,7 +75,9 @@ export default function HomePage() {
             <section className="w-full py-12 md:py-24 lg:py-32 bg-background px-4">
                 <div className="container mx-auto space-y-8">
                     <div className="text-center space-y-2">
-                        <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl">이달의 추천 체험</h2>
+                        <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl">
+                            이달의 추천 체험
+                        </h2>
                         <p className="text-muted-foreground md:text-xl">
                             지금 가장 인기 있는 농어촌 체험 프로그램들을 만나보세요.
                         </p>
@@ -115,39 +85,33 @@ export default function HomePage() {
 
                     <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
                         {experiences.map((c, i) => (
-                            <div key={i} className="flex flex-col rounded border bg-white shadow-sm h-full">
+                            <div
+                                key={i}
+                                className="flex flex-col rounded border bg-white shadow-sm h-full"
+                            >
                                 <img
                                     src={c.imageUrl}
                                     alt={`${c.title} 이미지`}
                                     className="aspect-video object-cover rounded-t"
                                 />
                                 <div className="p-4 flex flex-col flex-1">
-                                    {/* 제목 */}
                                     <h3 className="font-semibold text-lg truncate">{c.title}</h3>
-
-                                    {/* 설명 */}
                                     <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
                                         {c.description}
                                     </p>
-
-                                    {/* 위치 + 가격 */}
                                     <div className="flex items-center justify-between text-sm text-muted-foreground my-3">
-              <span className="inline-flex items-center gap-1">
-                <MapPin className="h-4 w-4" />
-                  {c.location}
-              </span>
+                    <span className="inline-flex items-center gap-1">
+                      <MapPin className="h-4 w-4" />
+                        {c.location}
+                    </span>
                                         <span>{c.price.toLocaleString()}원</span>
                                     </div>
-
-                                    {/* 해시태그 */}
                                     <div className="text-xs text-muted-foreground mb-3">
                                         {c.hashTag.join(" ")}
                                     </div>
-
-                                    {/* 버튼 (항상 하단 고정) */}
                                     <Link
                                         className="block w-full text-center px-3 py-2 rounded bg-primary text-primary-foreground mt-auto"
-                                        to={`/experiences/${c.id}`} // id 있으면 교체
+                                        to={`/experiences/${c.id}`}
                                     >
                                         자세히 보기
                                     </Link>
@@ -161,30 +125,36 @@ export default function HomePage() {
             {/* How It Works */}
             <section className="w-full py-12 md:py-24 lg:py-32 bg-secondary px-4">
                 <div className="container mx-auto space-y-8 text-center">
-                    <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl">브라보 농어촌 라이프, 어떻게 작동하나요?</h2>
+                    <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl">
+                        브라보 농어촌 라이프, 어떻게 작동하나요?
+                    </h2>
                     <p className="text-muted-foreground md:text-xl max-w-2xl mx-auto">
-                        디지털에 익숙하지 않은 농어촌민도, 다양한 체험을 찾는 도시민도 모두를 위한 쉽고 편리한 플랫폼입니다.
+                        디지털에 익숙하지 않은 농어촌민도, 다양한 체험을 찾는 도시민도 모두를
+                        위한 쉽고 편리한 플랫폼입니다.
                     </p>
                     <div className="grid gap-8 md:grid-cols-3">
                         <div className="p-6 flex flex-col items-center text-center rounded border bg-white">
-                            <Sparkles className="h-12 w-12 text-primary mb-4"/>
+                            <Sparkles className="h-12 w-12 text-primary mb-4" />
                             <h3 className="font-semibold mb-2">AI 홍보글 자동 생성</h3>
                             <p className="text-sm text-muted-foreground">
-                                최소한의 정보만 입력하면 AI가 매력적인 체험 소개글을 자동으로 작성해드립니다.
+                                최소한의 정보만 입력하면 AI가 매력적인 체험 소개글을 자동으로
+                                작성해드립니다.
                             </p>
                         </div>
                         <div className="p-6 flex flex-col items-center text-center rounded border bg-white">
-                            <Leaf className="h-12 w-12 text-primary mb-4"/>
+                            <Leaf className="h-12 w-12 text-primary mb-4" />
                             <h3 className="font-semibold mb-2">해시태그 기반 큐레이션</h3>
                             <p className="text-sm text-muted-foreground">
-                                다양한 해시태그와 검색 기능을 통해 원하는 체험을 쉽고 빠르게 찾아보세요.
+                                다양한 해시태그와 검색 기능을 통해 원하는 체험을 쉽고 빠르게
+                                찾아보세요.
                             </p>
                         </div>
                         <div className="p-6 flex flex-col items-center text-center rounded border bg-white">
-                            <Users className="h-12 w-12 text-primary mb-4"/>
+                            <Users className="h-12 w-12 text-primary mb-4" />
                             <h3 className="font-semibold mb-2">도농 상생 O2O</h3>
                             <p className="text-sm text-muted-foreground">
-                                온라인에서 쉽게 정보를 얻고 예약하여 오프라인 체험으로 이어지는 상생 구조를 만듭니다.
+                                온라인에서 쉽게 정보를 얻고 예약하여 오프라인 체험으로 이어지는
+                                상생 구조를 만듭니다.
                             </p>
                         </div>
                     </div>
@@ -192,16 +162,19 @@ export default function HomePage() {
             </section>
 
             {/* CTA */}
-            <section
-                className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
+            <section className="w-full py-12 md:py-24 lg:py-32 bg-primary text-primary-foreground flex flex-col items-center justify-center text-center px-4">
                 <div className="space-y-4">
                     <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl">
                         농어촌민이신가요? 당신의 삶을 공유하고 수익을 창출하세요!
                     </h2>
                     <p className="mx-auto max-w-[700px] text-lg md:text-xl">
-                        복잡한 기술 없이도 당신의 소중한 자원과 프로그램을 도시민에게 알릴 수 있습니다.
+                        복잡한 기술 없이도 당신의 소중한 자원과 프로그램을 도시민에게 알릴
+                        수 있습니다.
                     </p>
-                    <Link className="inline-block px-4 py-2 rounded bg-primary-foreground text-primary" to="/register">
+                    <Link
+                        className="inline-block px-4 py-2 rounded bg-primary-foreground text-primary"
+                        to="/register"
+                    >
                         지금 바로 체험 등록하기
                     </Link>
                 </div>


### PR DESCRIPTION
- ElasticSearch 검색어 기능 구현
 - 의존성 추가 
 - 검색 기능 서비스 클래스 따로 구현
- Elasticsearch 관련
 - Document 클랠스 구현 및 설정완료
 - 프론트와 연동 성공
- `/api/v1/experience/search` 경로의 GET 요청을 처리
 - 제목과 키워드 기준으로 엘라스틱 서치 내에 저장된 문서를 조회해 검색 결과 반환
 - ngram 형태소 분석으로 단어를 보다 짧게 토큰으로 저장
 - 저장할 때와 읽을 때의 tokenizer가 달라 정확도가 약간 부족함  